### PR TITLE
fix(x11): read the primary monitor via RandR instead of xrandr's combined-root text

### DIFF
--- a/bol/deps.py
+++ b/bol/deps.py
@@ -120,3 +120,14 @@ def ensure_gui_deps(install=True):
              f"('pip install --user {' '.join(GUI_INSTALL_REQUIREMENTS)}'). "
              "The AppImage and Flatpak already bundle this Python toolkit.")
     return missing
+
+
+# python-xlib (+ its six dependency): lets bol.x11 query the primary monitor
+# through RandR directly instead of parsing `xrandr` CLI text. Bundled in the
+# AppImage/Flatpak/.deb like the GUI toolkit, but optional: bol.x11 falls
+# back to the xrandr CLI when it's missing, so nothing here is pip-installed
+# on demand.
+X11_DEPS = {
+    "Xlib": "python-xlib==0.33",
+    "six": "six==1.17.0",
+}

--- a/bol/util.py
+++ b/bol/util.py
@@ -5,8 +5,6 @@ import http.client
 import fcntl
 import json
 import os
-import re
-import shutil
 import socket
 import subprocess
 import tempfile
@@ -195,14 +193,8 @@ def asset_url(release, predicate):
     return None, None, 0
 
 
-def _screen_wh():
-    """Primary screen WxH from xrandr (for gamescope sizing), or None."""
-    if not shutil.which("xrandr"):
-        return None
-    try:
-        out = subprocess.run(["xrandr"], capture_output=True, text=True,
-                             timeout=5).stdout
-    except Exception:
-        return None
-    m = re.search(r"current\s+(\d+)\s+x\s+(\d+)", out)
-    return (m.group(1), m.group(2)) if m else None
+def _screen_wh(runner=None):
+    """Primary screen WxH (for gamescope/Wine desktop sizing), or None. See
+    bol.x11.primary_output_size for how the primary monitor is found."""
+    from .x11 import primary_output_size
+    return primary_output_size(runner)

--- a/bol/x11.py
+++ b/bol/x11.py
@@ -1,0 +1,95 @@
+"""bol.x11 - primary-monitor size via the X11 RandR extension."""
+# SPDX-License-Identifier: MIT
+import re
+import shutil
+import subprocess
+
+from .deps import have
+
+
+def _primary_via_xlib():
+    """(width, height) strings for the primary monitor via python-xlib's
+    RandR GetMonitors, or None if python-xlib is unavailable/unusable."""
+    if not have("Xlib"):
+        return None
+    try:
+        from Xlib import display as xdisplay
+        from Xlib import error as xerror
+    except ImportError:
+        return None
+    connection_errors = (xerror.DisplayError, xerror.ConnectionClosedError,
+                         OSError)
+    try:
+        d = xdisplay.Display()
+    except connection_errors:
+        return None
+    try:
+        root = d.screen().root
+        get_monitors = getattr(root, "xrandr_get_monitors", None)
+        if get_monitors is None:
+            return None  # server predates RandR 1.5
+        monitors = get_monitors(is_active=True).monitors
+        if not monitors:
+            return None
+        primary = next((m for m in monitors if m.primary), monitors[0])
+        return (str(primary.width_in_pixels), str(primary.height_in_pixels))
+    except (xerror.XError, *connection_errors, AttributeError, IndexError):
+        return None
+    finally:
+        try:
+            d.close()
+        except Exception:
+            pass
+
+
+def _primary_via_xrandr_cli(runner=None):
+    """Fallback: shell out to `xrandr` and parse its text output."""
+    binary = shutil.which("xrandr")
+    # A supplied runner is the unit-test seam; it must not depend on whether
+    # the test host happens to have xrandr installed.
+    if not binary and runner is not None:
+        binary = "xrandr"
+    if not binary:
+        return None
+    runner = runner or subprocess.run
+
+    def run(args):
+        try:
+            return runner([binary] + args, capture_output=True, text=True,
+                          timeout=5, check=False)
+        except (OSError, subprocess.SubprocessError):
+            return None
+
+    result = run(["--listmonitors"])
+    if result is not None and getattr(result, "returncode", 1) == 0:
+        first = primary = None
+        for line in getattr(result, "stdout", "").splitlines():
+            m = re.search(r"^\s*\d+:\s+\+(\*)?\S+\s+(\d+)/\d+x(\d+)/\d+\+",
+                          line)
+            if not m:
+                continue
+            wh = (m.group(2), m.group(3))
+            first = first or wh
+            if m.group(1):
+                primary = wh
+                break
+        if primary or first:
+            return primary or first
+
+    result = run([])
+    if result is None:
+        return None
+    m = re.search(r"current\s+(\d+)\s+x\s+(\d+)",
+                  getattr(result, "stdout", ""))
+    return (m.group(1), m.group(2)) if m else None
+
+
+def primary_output_size(runner=None):
+    """Primary monitor's (width, height) as strings, or None.
+
+    Tries python-xlib's structured RandR GetMonitors reply first; falls back
+    to parsing xrandr CLI text when python-xlib is missing, the X server
+    predates RandR 1.5, or the connection fails. `runner` only affects the
+    CLI fallback.
+    """
+    return _primary_via_xlib() or _primary_via_xrandr_cli(runner)

--- a/flatpak/io.github.wyze3306.BedrockOnLinux.yml
+++ b/flatpak/io.github.wyze3306.BedrockOnLinux.yml
@@ -150,6 +150,23 @@ modules:
         url: https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl
         sha256: 5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e
 
+  # python-xlib (+ its six dep): lets bol.x11 read the primary monitor's size
+  # straight from the X server's RandR extension instead of parsing `xrandr`
+  # CLI text. Optional (bol.x11 falls back to the xrandr CLI without it),
+  # but vendored the same way since the runtime has no pip.
+  - name: python3-xlib
+    buildsystem: simple
+    build-commands:
+      - for w in *.whl; do python3 -m zipfile -e "$w" /app/lib/python3.12/site-packages/; done
+      - /app/bin/python3 -c "import Xlib; print('python-xlib', Xlib.__version_string__)"
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/fc/b8/ff33610932e0ee81ae7f1269c890f697d56ff74b9f5b2ee5d9b7fa2c5355/python_xlib-0.33-py2.py3-none-any.whl
+        sha256: c3534038d42e0df2f1392a1b30a15a4ff5fdc2b86cfa94f072bf11b10a164398
+      - type: file
+        url: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
+        sha256: 4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274
+
   # zstd CLI for the one .pkg.tar.zst (libcurl) the launcher extracts;
   # Python's tarfile can't read zstd and the runtime ships no unzstd.
   - name: zstd

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -133,12 +133,13 @@ for library in "$PYLIB/libtcl8.6.so" "$PYLIB/libtk8.6.so"; do
   }
 done
 
-echo "== installing portable cryptography + certifi + customtkinter into the bundle"
+echo "== installing portable cryptography + certifi + customtkinter + python-xlib into the bundle"
 "$PYBIN" -m pip install --no-cache-dir --no-compile \
     --no-deps \
     'cryptography==43.0.3' 'certifi==2026.6.17' \
     'cffi==2.0.0' 'pycparser==3.0' \
     'customtkinter==5.2.2' 'darkdetect==0.8.0' 'packaging==26.2' \
+    'python-xlib==0.33' 'six==1.17.0' \
     >/dev/null
 
 PY3="$PYLIB/python3.12"
@@ -290,6 +291,7 @@ import urllib.request
 import _tkinter
 import cryptography
 import customtkinter
+import Xlib
 from importlib.metadata import version
 assert _tkinter.TK_VERSION == "8.6", _tkinter.TK_VERSION   # Xft build, not PBS Tk9
 expected = {
@@ -300,6 +302,8 @@ expected = {
     "customtkinter": "5.2.2",
     "darkdetect": "0.8.0",
     "packaging": "26.2",
+    "python-xlib": "0.33",
+    "six": "1.17.0",
 }
 actual = {package: version(package) for package in expected}
 assert actual == expected, (actual, expected)

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -29,15 +29,20 @@ cp -r "$SRC/bol"                       "$PKG/usr/lib/bedrock-on-linux/bol"
 # Bundle the GUI toolkit (customtkinter + darkdetect + packaging — pure Python,
 # not packaged by Debian) next to bol/ so it's on sys.path; a real dir means
 # customtkinter's theme/font assets load fine. cryptography/tk stay apt deps.
+# python-xlib (+ six) is bundled the same way for bol.x11's primary-monitor
+# lookup; it's optional (bol.x11 falls back to the xrandr CLI without it).
 python3 -m pip install --quiet --no-cache-dir --no-compile --no-deps --target \
   "$PKG/usr/lib/bedrock-on-linux" \
-  'customtkinter==5.2.2' 'darkdetect==0.8.0' 'packaging==26.2'
+  'customtkinter==5.2.2' 'darkdetect==0.8.0' 'packaging==26.2' \
+  'python-xlib==0.33' 'six==1.17.0'
 rm -rf "$PKG/usr/lib/bedrock-on-linux"/bin 2>/dev/null || true
 find "$PKG/usr/lib/bedrock-on-linux" -name __pycache__ -type d -exec rm -rf {} +
 for metadata in \
   "$PKG/usr/lib/bedrock-on-linux/customtkinter-5.2.2.dist-info" \
   "$PKG/usr/lib/bedrock-on-linux/darkdetect-0.8.0.dist-info" \
-  "$PKG/usr/lib/bedrock-on-linux/packaging-26.2.dist-info"; do
+  "$PKG/usr/lib/bedrock-on-linux/packaging-26.2.dist-info" \
+  "$PKG/usr/lib/bedrock-on-linux/python_xlib-0.33.dist-info" \
+  "$PKG/usr/lib/bedrock-on-linux/six-1.17.0.dist-info"; do
   [[ -d "$metadata" ]] || {
     echo "missing pinned dependency metadata: $metadata" >&2
     exit 1

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,26 @@
+"""Tests for bol.util's screen-geometry helper."""
+# SPDX-License-Identifier: MIT
+
+import unittest
+from unittest import mock
+
+from bol import util
+
+
+class ScreenWHTests(unittest.TestCase):
+    def test_delegates_to_x11_primary_output_size(self):
+        with mock.patch("bol.x11.primary_output_size",
+                         return_value=("1920", "1080")) as mocked:
+            self.assertEqual(util._screen_wh(), ("1920", "1080"))
+        mocked.assert_called_once_with(None)
+
+    def test_passes_runner_through(self):
+        runner = object()
+        with mock.patch("bol.x11.primary_output_size",
+                         return_value=None) as mocked:
+            self.assertIsNone(util._screen_wh(runner=runner))
+        mocked.assert_called_once_with(runner)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_x11.py
+++ b/tests/test_x11.py
@@ -1,0 +1,263 @@
+"""Tests for bol.x11's primary-monitor size lookup."""
+# SPDX-License-Identifier: MIT
+
+import subprocess
+import sys
+import types
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from bol import x11
+
+
+def result(stdout="", returncode=0):
+    return SimpleNamespace(stdout=stdout, returncode=returncode)
+
+
+DUAL_MONITOR_PRIMARY_SECOND = (
+    "Monitors: 2\n"
+    " 0: +HDMI-A-0 1920/530x1080/300+1920+0  HDMI-A-0\n"
+    " 1: +*HDMI-A-1 1920/530x1080/300+0+0  HDMI-A-1\n"
+)
+
+SINGLE_MONITOR = (
+    "Monitors: 1\n"
+    " 0: +*eDP-1 1920/340x1080/190+0+0  eDP-1\n"
+)
+
+NO_PRIMARY_FLAGGED = (
+    "Monitors: 2\n"
+    " 0: +HDMI-A-0 1920/530x1080/300+0+0  HDMI-A-0\n"
+    " 1: +HDMI-A-1 2560/597x1440/336+1920+0  HDMI-A-1\n"
+)
+
+BARE_XRANDR_COMBINED = (
+    "Screen 0: minimum 320 x 200, current 3840 x 1080, maximum 16384 x "
+    "16384\n"
+)
+
+
+class XrandrCliFallbackTests(unittest.TestCase):
+    """Exercises _primary_via_xrandr_cli directly, and through
+    primary_output_size() with the python-xlib path forced off (it isn't
+    installed on the test host either way)."""
+
+    def setUp(self):
+        patcher = mock.patch.object(x11.shutil, "which", return_value="xrandr")
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        have_patcher = mock.patch.object(x11, "have", return_value=False)
+        have_patcher.start()
+        self.addCleanup(have_patcher.stop)
+
+    def test_dual_monitor_uses_primary_not_combined_root(self):
+        def runner(args, **_kwargs):
+            self.assertIn("--listmonitors", args)
+            return result(DUAL_MONITOR_PRIMARY_SECOND)
+
+        self.assertEqual(x11.primary_output_size(runner=runner),
+                          ("1920", "1080"))
+
+    def test_single_monitor(self):
+        def runner(args, **_kwargs):
+            return result(SINGLE_MONITOR)
+
+        self.assertEqual(x11.primary_output_size(runner=runner),
+                          ("1920", "1080"))
+
+    def test_no_primary_flagged_falls_back_to_first_listed_monitor(self):
+        def runner(args, **_kwargs):
+            return result(NO_PRIMARY_FLAGGED)
+
+        self.assertEqual(x11.primary_output_size(runner=runner),
+                          ("1920", "1080"))
+
+    def test_listmonitors_unsupported_falls_back_to_combined_root(self):
+        def runner(args, **_kwargs):
+            if "--listmonitors" in args:
+                return result(returncode=1)
+            return result(BARE_XRANDR_COMBINED)
+
+        self.assertEqual(x11.primary_output_size(runner=runner),
+                          ("3840", "1080"))
+
+    def test_xrandr_missing_returns_none(self):
+        with mock.patch.object(x11.shutil, "which", return_value=None):
+            self.assertIsNone(x11.primary_output_size())
+
+    def test_xrandr_timeout_returns_none(self):
+        def runner(args, **_kwargs):
+            raise subprocess.TimeoutExpired("xrandr", 5)
+
+        self.assertIsNone(x11.primary_output_size(runner=runner))
+
+    def test_unparseable_output_returns_none(self):
+        def runner(args, **_kwargs):
+            return result("nothing useful here\n")
+
+        self.assertIsNone(x11.primary_output_size(runner=runner))
+
+
+class FakeMonitor:
+    def __init__(self, primary, width, height):
+        self.primary = primary
+        self.width_in_pixels = width
+        self.height_in_pixels = height
+
+
+class FakeMonitorsReply:
+    def __init__(self, monitors):
+        self.monitors = monitors
+
+
+class FakeRoot:
+    def __init__(self, monitors=None, supports_get_monitors=True,
+                 get_monitors_raises=None):
+        if supports_get_monitors:
+            self._monitors = monitors or []
+            self._get_monitors_raises = get_monitors_raises
+            self.xrandr_get_monitors = self._get_monitors
+
+    def _get_monitors(self, is_active=True):
+        if self._get_monitors_raises is not None:
+            raise self._get_monitors_raises
+        return FakeMonitorsReply(self._monitors)
+
+
+class FakeScreen:
+    def __init__(self, root):
+        self.root = root
+
+
+class FakeDisplay:
+    fail_to_connect = None
+    close_raises = None
+    root = None
+
+    def __init__(self):
+        if type(self).fail_to_connect is not None:
+            raise type(self).fail_to_connect
+        self.closed = False
+
+    def screen(self):
+        return FakeScreen(type(self).root)
+
+    def close(self):
+        self.closed = True
+        if type(self).close_raises is not None:
+            raise type(self).close_raises
+
+
+class XlibDisplayError(Exception):
+    pass
+
+
+class XlibXError(Exception):
+    pass
+
+
+class XlibConnectionClosedError(Exception):
+    pass
+
+
+class XlibPathTests(unittest.TestCase):
+    """Exercises _primary_via_xlib by injecting fake Xlib.display/Xlib.error
+    modules. python-xlib is not installed on the test host, so this is the
+    only way to cover the primary code path without a real X server."""
+
+    def setUp(self):
+        FakeDisplay.fail_to_connect = None
+        FakeDisplay.close_raises = None
+        FakeDisplay.root = None
+
+        fake_xlib = types.ModuleType("Xlib")
+        fake_display_mod = types.ModuleType("Xlib.display")
+        fake_error_mod = types.ModuleType("Xlib.error")
+        fake_display_mod.Display = FakeDisplay
+        fake_error_mod.DisplayError = XlibDisplayError
+        fake_error_mod.XError = XlibXError
+        fake_error_mod.ConnectionClosedError = XlibConnectionClosedError
+        fake_xlib.display = fake_display_mod
+        fake_xlib.error = fake_error_mod
+
+        modules_patcher = mock.patch.dict(sys.modules, {
+            "Xlib": fake_xlib,
+            "Xlib.display": fake_display_mod,
+            "Xlib.error": fake_error_mod,
+        })
+        modules_patcher.start()
+        self.addCleanup(modules_patcher.stop)
+
+        have_patcher = mock.patch.object(x11, "have", return_value=True)
+        have_patcher.start()
+        self.addCleanup(have_patcher.stop)
+
+    def test_primary_flagged_monitor_wins_over_first(self):
+        FakeDisplay.root = FakeRoot(monitors=[
+            FakeMonitor(False, "2560", "1440"),
+            FakeMonitor(True, "1920", "1080"),
+        ])
+        self.assertEqual(x11._primary_via_xlib(), ("1920", "1080"))
+
+    def test_no_primary_flagged_falls_back_to_first_monitor(self):
+        FakeDisplay.root = FakeRoot(monitors=[
+            FakeMonitor(False, "1920", "1080"),
+            FakeMonitor(False, "2560", "1440"),
+        ])
+        self.assertEqual(x11._primary_via_xlib(), ("1920", "1080"))
+
+    def test_empty_monitor_list_returns_none(self):
+        FakeDisplay.root = FakeRoot(monitors=[])
+        self.assertIsNone(x11._primary_via_xlib())
+
+    def test_pre_randr_1_5_server_returns_none(self):
+        FakeDisplay.root = FakeRoot(supports_get_monitors=False)
+        self.assertIsNone(x11._primary_via_xlib())
+
+    def test_connection_failure_returns_none(self):
+        FakeDisplay.fail_to_connect = XlibDisplayError("no display")
+        self.assertIsNone(x11._primary_via_xlib())
+
+    def test_connection_dropped_mid_query_returns_none(self):
+        # Issue: a ConnectionClosedError (dropped X connection, e.g. SSH
+        # X-forwarding cut or the X server restarting mid-request) is
+        # neither an XError nor an OSError; it must still be caught rather
+        # than crash the caller.
+        FakeDisplay.root = FakeRoot(
+            get_monitors_raises=XlibConnectionClosedError("gone"))
+        self.assertIsNone(x11._primary_via_xlib())
+
+    def test_close_raising_does_not_mask_a_successful_result(self):
+        FakeDisplay.root = FakeRoot(monitors=[FakeMonitor(True, "1920", "1080")])
+        FakeDisplay.close_raises = XlibConnectionClosedError("gone on close")
+        self.assertEqual(x11._primary_via_xlib(), ("1920", "1080"))
+
+    def test_display_is_closed_after_use(self):
+        FakeDisplay.root = FakeRoot(monitors=[FakeMonitor(True, "1920", "1080")])
+        seen = {}
+
+        real_init = FakeDisplay.__init__
+
+        def tracking_init(self):
+            real_init(self)
+            seen["instance"] = self
+
+        with mock.patch.object(FakeDisplay, "__init__", tracking_init):
+            x11._primary_via_xlib()
+        self.assertTrue(seen["instance"].closed)
+
+    def test_xlib_path_wins_over_cli_fallback(self):
+        FakeDisplay.root = FakeRoot(monitors=[FakeMonitor(True, "1920", "1080")])
+
+        def must_not_run(*_args, **_kwargs):
+            raise AssertionError("CLI fallback must not run when Xlib succeeds")
+
+        with mock.patch.object(x11.shutil, "which", return_value="xrandr"):
+            self.assertEqual(
+                x11.primary_output_size(runner=must_not_run),
+                ("1920", "1080"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Looking to help out @HouseIndoril with #36. Confirmed the diagnosis independently: `_screen_wh()` reads xrandr's combined-root `current WxH`, which on a dual-monitor setup is the full virtual desktop (e.g. 3840x1080 for two 1920x1080 screens), not any one monitor. That oversizes both the gamescope window and the Wine cursor-confinement desktop from #26.

Their patch (parsing `--listmonitors` with a regex for the primary-flagged output) is a solid fix and I kept the same approach as a fallback. But since we're touching it, went one step further: `bol/x11.py` now reads the primary monitor straight from RandR's GetMonitors reply via python-xlib, the same request `xrandr --listmonitors` sends under the hood, just without shelling out and scraping CLI text. Falls back to the CLI parse if python-xlib isn't available or the server predates RandR 1.5. Bundled python-xlib (+ its six dep) in the .deb/AppImage/Flatpak the same way customtkinter already is.

Tested: full suite passes, added tests/test_x11.py covering both paths, and dry-ran the .deb build locally to confirm the bundled dependency installs and imports correctly.