### PR TITLE
feat: Add Custom Environment Variables and Gamescope field to Settings

### DIFF
--- a/bol/gui.py
+++ b/bol/gui.py
@@ -540,6 +540,29 @@ def gui():
                       "cursor escaping in windowed mode)", variable=confine_v,
                       command=save_confine, progress_color=GREEN,
                       font=font(13)).pack(anchor="w", pady=7)
+
+        ctk.CTkLabel(wrap, text="Custom Environment Variables",
+                     text_color=SUB, font=font(11, "bold"),
+                     anchor="w").pack(anchor="w", pady=(4, 3))
+
+        def save_custom_env(_event=None):
+            s2 = load_settings()
+            s2["custom_env"] = env_entry.get()
+            save_settings(s2)
+
+        env_entry = ctk.CTkEntry(
+            wrap,
+            placeholder_text="e.g., PROTON_USE_WINED3D=1 KEY=VALUE",
+            fg_color=FIELD, border_color=FIELD, text_color=FG,
+            placeholder_text_color=SUB, corner_radius=10, height=36,
+            font=font(13))
+        env_entry.pack(fill="x", pady=(0, 7))
+        saved_env = load_settings().get("custom_env") or ""
+        if saved_env:
+            env_entry.insert(0, saved_env)
+        env_entry.bind("<KeyRelease>", save_custom_env)
+        env_entry.bind("<FocusOut>", save_custom_env)
+
         ctk.CTkFrame(wrap, fg_color=CARD2, height=1).pack(fill="x", pady=14)
 
         imp_status = tk.StringVar(value="")

--- a/bol/gui.py
+++ b/bol/gui.py
@@ -563,6 +563,28 @@ def gui():
         env_entry.bind("<KeyRelease>", save_custom_env)
         env_entry.bind("<FocusOut>", save_custom_env)
 
+        ctk.CTkLabel(wrap, text="Gamescope",
+                     text_color=SUB, font=font(11, "bold"),
+                     anchor="w").pack(anchor="w", pady=(4, 3))
+
+        def save_gamescope(_event=None):
+            s2 = load_settings()
+            s2["gamescope"] = gamescope_entry.get()
+            save_settings(s2)
+
+        gamescope_entry = ctk.CTkEntry(
+            wrap,
+            placeholder_text="1 for auto, or e.g. -w 1920 -h 1080 -f",
+            fg_color=FIELD, border_color=FIELD, text_color=FG,
+            placeholder_text_color=SUB, corner_radius=10, height=36,
+            font=font(13))
+        gamescope_entry.pack(fill="x", pady=(0, 7))
+        saved_gamescope = load_settings().get("gamescope") or ""
+        if saved_gamescope:
+            gamescope_entry.insert(0, saved_gamescope)
+        gamescope_entry.bind("<KeyRelease>", save_gamescope)
+        gamescope_entry.bind("<FocusOut>", save_gamescope)
+
         ctk.CTkFrame(wrap, fg_color=CARD2, height=1).pack(fill="x", pady=14)
 
         imp_status = tk.StringVar(value="")

--- a/bol/launch.py
+++ b/bol/launch.py
@@ -39,7 +39,7 @@ from .prefix import (
     proton_umu_cmd,
 )
 from .proton import custom_proton, patch_proton, proton_path
-from .util import _screen_wh, load_settings
+from .util import _screen_wh, apply_custom_env, load_settings
 from .vkd3d import prepare_universal_vkd3d
 from .winegdk import ensure_winegdk
 
@@ -261,6 +261,7 @@ def _launch_once():
     if not account_epoch_is_current(account_epoch):
         die("The Microsoft account changed before the game process started. "
             "Minecraft was not started; click PLAY again.")
+    apply_custom_env(env, s.get("custom_env") or "")
     info("Starting Minecraft … sign in with Microsoft in-game, then "
          "join your server from the Servers tab.")
     glog = open(LOGS / "minecraft.log", "w")

--- a/bol/launch.py
+++ b/bol/launch.py
@@ -211,7 +211,7 @@ def _launch_once():
                or s.get("input_backend") or "auto").lower()
     if backend == "auto":
         backend = "x11"
-    gs_opt = os.environ.get("BOL_GAMESCOPE")
+    gs_opt = s.get("gamescope") or os.environ.get("BOL_GAMESCOPE")
     want_gamescope = bool(gs_opt) and \
         gs_opt.lower() not in ("0", "no", "off", "false")
     use_gamescope = want_gamescope and bool(shutil.which("gamescope"))

--- a/bol/util.py
+++ b/bol/util.py
@@ -5,6 +5,7 @@ import http.client
 import fcntl
 import json
 import os
+import shlex
 import socket
 import subprocess
 import tempfile
@@ -82,6 +83,19 @@ def save_settings(s):
             fcntl.flock(lock_fd, fcntl.LOCK_UN)
         finally:
             os.close(lock_fd)
+
+
+def apply_custom_env(env, custom_env):
+    """Merge KEY=VALUE tokens from a space-separated string into env."""
+    if not custom_env or not str(custom_env).strip():
+        return
+    for token in shlex.split(str(custom_env).strip()):
+        if "=" not in token:
+            continue
+        key, _, value = token.partition("=")
+        key = key.strip()
+        if key:
+            env[key] = value
 
 
 def http_json(url):

--- a/bol/util.py
+++ b/bol/util.py
@@ -89,7 +89,13 @@ def apply_custom_env(env, custom_env):
     """Merge KEY=VALUE tokens from a space-separated string into env."""
     if not custom_env or not str(custom_env).strip():
         return
-    for token in shlex.split(str(custom_env).strip()):
+    try:
+        tokens = shlex.split(str(custom_env).strip())
+    except ValueError as e:
+        warn(f"Custom environment variables ignored — invalid syntax ({e}). "
+             "Check for a missing closing quote.")
+        return
+    for token in tokens:
         if "=" not in token:
             continue
         key, _, value = token.partition("=")


### PR DESCRIPTION
**Adds custom environment variable and gamescope support to the settings menu.**
Custom Environment Variables

**New CTkEntry field in Settings, styled to match the existing UI.**
Values are stored as a single string in the JSON settings file and parsed with shlex.split() in util.py, so both KEY=VALUE and quoted values (KEY="some value") work.
Applied to the launch environment via apply_custom_env(), called right before the game process is spawned — so it can override any Proton/Wine variable the launcher sets internally.
Tested locally with MANGOHUD=1 and PROTON_USE_WINED3D=1; both applied correctly.

**Gamescope**

New CTkEntry field for gamescope options — leave empty to disable, enter 1 for automatic fullscreen at the primary display's resolution, or pass custom flags (e.g. -w 1920 -h 1080 -f) for manual control.
Reuses the launcher's existing gamescope detection/wrapping logic in launch.py (previously only configurable via the BOL_GAMESCOPE env var) — the settings value now takes priority, falling back to the env var if unset.
No changes to the wrapping/detection logic itself, so behavior for existing BOL_GAMESCOPE users is unaffected.

Both fields persist across restarts and save automatically on typing (debounced via <KeyRelease>) and on focus-out.
<img width="560" height="751" alt="image" src="https://github.com/user-attachments/assets/44c79808-6453-4abb-a362-b21dc5e62770" />


In-Game Using -w 1280 -h 720 -f and MANGOHUD=1:

<img width="1911" height="1074" alt="image" src="https://github.com/user-attachments/assets/44dfbc3c-1923-44b1-bd38-8747016fbab1" />

