### PR TITLE
fix: decode subprocess output with errors="replace" to prevent UnicodeDecodeError crash on hybrid GPU systems

### DIFF
--- a/bol/gpu_safety.py
+++ b/bol/gpu_safety.py
@@ -56,6 +56,7 @@ def _xrandr_provider_count(env: Mapping[str, str], runner=None) -> Optional[int]
             env=dict(env),
             capture_output=True,
             text=True,
+            errors="replace",
             timeout=4,
             check=False,
         )
@@ -448,6 +449,7 @@ def _kernel_journal_text(binary: str, runner, boot: int) -> Optional[str]:
             args,
             capture_output=True,
             text=True,
+            errors="replace",
             timeout=5,
             check=False,
         )

--- a/bol/util.py
+++ b/bol/util.py
@@ -29,6 +29,14 @@ from .log import IS_TTY, die, warn
 
 def run(cmd, **kw):
     kw.setdefault("check", True)
+    # Some hardware/locale combos emit non-UTF-8 bytes on stdout/stderr
+    # (e.g. xrandr output on certain Nvidia/Intel hybrid setups under a
+    # non-English locale). When decoding is requested (text=True or an
+    # explicit encoding), don't let a single bad byte crash the whole
+    # launcher — fall back to dropping undecodable bytes unless the
+    # caller already specified its own `errors` policy.
+    if (kw.get("text") or kw.get("encoding")) and "errors" not in kw:
+        kw["errors"] = "ignore"
     return subprocess.run(cmd, **kw)
 
 

--- a/bol/util.py
+++ b/bol/util.py
@@ -29,14 +29,6 @@ from .log import IS_TTY, die, warn
 
 def run(cmd, **kw):
     kw.setdefault("check", True)
-    # Some hardware/locale combos emit non-UTF-8 bytes on stdout/stderr
-    # (e.g. xrandr output on certain Nvidia/Intel hybrid setups under a
-    # non-English locale). When decoding is requested (text=True or an
-    # explicit encoding), don't let a single bad byte crash the whole
-    # launcher — fall back to dropping undecodable bytes unless the
-    # caller already specified its own `errors` policy.
-    if (kw.get("text") or kw.get("encoding")) and "errors" not in kw:
-        kw["errors"] = "ignore"
     return subprocess.run(cmd, **kw)
 
 

--- a/bol/x11.py
+++ b/bol/x11.py
@@ -56,7 +56,7 @@ def _primary_via_xrandr_cli(runner=None):
     def run(args):
         try:
             return runner([binary] + args, capture_output=True, text=True,
-                          timeout=5, check=False)
+                          errors="replace", timeout=5, check=False)
         except (OSError, subprocess.SubprocessError):
             return None
 


### PR DESCRIPTION
## Summary

Fixes a startup crash (`'utf-8' codec can't decode byte 0xf3 in position 6332`)
reported on Linux Mint with hybrid Nvidia/Intel graphics.

`subprocess.run(..., text=True)` decodes stdout/stderr as UTF-8 with strict
error handling. On some hardware, `xrandr` and `journalctl` can emit stray
non-UTF-8 bytes (vendor/locale-dependent strings), which raises
`UnicodeDecodeError` and kills the launcher before it can even reach prefix
setup.

## Fix

Added `errors="replace"` to the three `runner(...)` call sites that parse
system command output:

- `gpu_safety.py` — `_xrandr_provider_count` (xrandr `--listproviders`)
- `gpu_safety.py` — `_kernel_journal_text` (journalctl)
- `x11.py` — `_primary_via_xrandr_cli`'s shared `run()` closure (covers both
  `xrandr --listmonitors` and the plain `xrandr` fallback)

I used `errors="replace"` rather than `errors="ignore"`: `ignore` silently
drops the offending bytes, which can splice two tokens together (e.g.
`nvidia<bad-byte>card` → `nvidiacard`) and corrupt the regex parsing these
functions rely on. `replace` swaps each bad byte for `�`, preserving string
structure so downstream `re.search` calls still match correctly, while still
fully preventing the crash.

## Credit

Root-caused and originally patched by @klesi in #43, who tracked the crash
down to unhandled decoding in `subprocess.run(text=True)` calls by extracting
and debugging the AppImage locally. This PR applies that fix at the current
call sites (which have since moved/consolidated into `gpu_safety.py` and
`x11.py`), using `errors="replace"` instead of `errors="ignore"` to avoid
silent token corruption in the regex-based parsing.

Closes #43