### PR TITLE
ci: add ruff, zizmor, and CodeQL static analysis

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -55,6 +55,8 @@ jobs:
       BOL_ALLOW_PARTIAL_ARTIFACTS: ${{ vars.BOL_ALLOW_PARTIAL_ARTIFACTS }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install the packaging toolchain
         run: |
@@ -158,6 +160,8 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Download the built artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
@@ -176,6 +180,8 @@ jobs:
             dist/BedrockOnLinux-*-inputs.sha256
 
       - name: Compute release metadata + bill of materials
+        env:
+          CHANNEL_INPUT: ${{ inputs.channel }}
         run: |
           ver="$(grep -m1 '^VERSION = ' bol/config.py | cut -d'"' -f2)"
           eng_rev="$(grep -m1 '^WINEGDK_BUILD_REV = ' bol/config.py | cut -d'"' -f2)"
@@ -185,7 +191,7 @@ jobs:
           xcurl_rev="$(grep -m1 '^OPENSSL_XCURL_REV = ' bol/config.py | cut -d'"' -f2)"
           vkd3d_hashes="$(grep -m1 '^VKD3D_OUTPUT_HASHES_SHA256=' \
             third_party/vkd3d-proton-universal/provenance.env | cut -d= -f2 | tr -d "'\"")"
-          channel="${{ inputs.channel || 'release' }}"
+          channel="${CHANNEL_INPUT:-release}"
           if [ "$channel" = "nightly" ]; then
             # Rolling nightly: one release/tag, moved to HEAD each run (see the
             # "Roll the nightly tag" step). Date + short commit in the name give

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -81,6 +81,8 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install packaging tools
         run: |

--- a/.github/workflows/build-vkd3d.yml
+++ b/.github/workflows/build-vkd3d.yml
@@ -47,6 +47,8 @@ jobs:
       sha256: ${{ steps.pack.outputs.sha256 }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Build universal vkd3d-proton in a pinned Trixie container
         run: |

--- a/.github/workflows/build-winegdk.yml
+++ b/.github/workflows/build-winegdk.yml
@@ -50,6 +50,8 @@ jobs:
       short: ${{ steps.pack.outputs.short }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Prepare work area on the large /mnt volume
         run: |

--- a/.github/workflows/build-xcurl.yml
+++ b/.github/workflows/build-xcurl.yml
@@ -49,6 +49,8 @@ jobs:
       rev: ${{ steps.build.outputs.rev }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Build the set from source in a pinned Trixie container
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Run the test suite
         run: |
           python3 -m venv .venv
@@ -29,6 +31,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Byte-compile the package
         run: python3 -m compileall -q bol
       - name: Shellcheck the scripts
@@ -45,6 +49,12 @@ jobs:
           echo "${sha}  actionlint.tar.gz" | sha256sum -c -
           tar -xzf actionlint.tar.gz actionlint
           ./actionlint -color
+      - name: Lint Python (ruff, pyflakes rules)
+        run: pipx run --spec 'ruff==0.14.3' ruff check --select F bol/ tests/
+      - name: Audit the workflows (zizmor)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: pipx run --spec 'zizmor==1.5.2' zizmor --persona=regular .github/workflows/
   cryptbase:
     # Wine runtime test for the from-source cryptbase RNG stub: proves
     # SystemFunction036 returns varied random bytes and does not recurse to a
@@ -53,6 +63,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Run scripts/test-cryptbase.sh in a pinned Trixie container
         run: |
           docker run --rm -v "$PWD:/repo" -w /repo \
@@ -78,6 +90,8 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Verify committed release pins resolve to a matching published asset
         run: |
           set -euo pipefail

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,62 @@
+# CodeQL static analysis for the Python launcher and the native C sources
+# (the DLL injector, the cryptbase RNG stub, and the XCurl CA shim: the
+# highest-risk code in the tree). Python needs no build; the C sources are
+# cross-compiled with mingw between init and analyze so the extractor observes
+# them. Results surface in the repository's code-scanning tab.
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: "0 8 * * 1" # weekly, Monday ~08:00 UTC
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      security-events: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: python
+            build-mode: none
+          - language: c-cpp
+            build-mode: manual
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Build the native C sources for the extractor
+        if: matrix.build-mode == 'manual'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends gcc-mingw-w64-x86-64
+          CC=x86_64-w64-mingw32-gcc
+          "$CC" -c -O2 -mrdrnd src/cryptbase-stub.c -o "$RUNNER_TEMP/cryptbase.o"
+          "$CC" -c -O2 src/xcurl-cashim.c -o "$RUNNER_TEMP/xcurl-cashim.o"
+          "$CC" -c -O2 src/injector.c -o "$RUNNER_TEMP/injector.o"
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,13 +54,18 @@ jobs:
       publish: ${{ steps.probe.outputs.publish }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Resolve pins and decide reuse-or-build per tier
         id: probe
+        env:
+          FORCE_REBUILD: ${{ inputs.force_rebuild }}
+          PUBLISH_INPUT: ${{ inputs.publish }}
         run: |
           set -euo pipefail
           repo="${{ github.repository }}"
-          force="${{ inputs.force_rebuild || 'false' }}"
+          force="${FORCE_REBUILD:-false}"
           cfg=bol/config.py
           xrev="$(grep -m1 '^OPENSSL_XCURL_REV = ' $cfg | cut -d'"' -f2)"
           xsha="$(grep -m1 '^OPENSSL_XCURL_ARCHIVE_SHA256 = ' $cfg | cut -d'"' -f2)"
@@ -94,7 +99,7 @@ jobs:
           if [ "${{ github.event_name }}" = "schedule" ]; then
             channel=nightly; publish=true
           else
-            channel=release; publish="${{ inputs.publish }}"
+            channel=release; publish="$PUBLISH_INPUT"
           fi
           {
             echo "build_xcurl=$bx"

--- a/bol/gui.py
+++ b/bol/gui.py
@@ -10,7 +10,6 @@ import sys
 import threading
 import zipfile
 from pathlib import Path
-from PIL import Image, ImageDraw
 
 from .auth import (
     NativeAuth,
@@ -192,7 +191,6 @@ def gui():
         return
 
     T = Theme
-    from .util import load_settings, save_settings
     s = load_settings()
     _init_beta = s.get("ui_is_beta", False)
     T.THEME_ACCENT = T.GOLD if _init_beta else T.GREEN
@@ -1026,7 +1024,6 @@ def gui():
         elif mode == "cancel":
             if getattr(acct_btn, "_confirm_cancel", False):
                 na.stop()
-                from .auth import msa_signed_in
                 acct_state("in" if msa_signed_in() else "out")
                 if ui.get("auth_dialog") and ui["auth_dialog"].winfo_exists():
                     ui["auth_dialog"].destroy()
@@ -1082,7 +1079,6 @@ def gui():
         ui["auth_dialog"] = d
         def on_close():
             na.stop()
-            from .auth import msa_signed_in
             acct_state("in" if msa_signed_in() else "out")
             d.destroy()
         d.protocol("WM_DELETE_WINDOW", on_close)
@@ -1585,7 +1581,6 @@ def gui():
     def render_markdown_to_text(widget, md, wrap_width=75):
         lines = md.split("\n")
         in_code_block = False
-        code_in_quote = False
         code_content = []
 
         for line in lines:
@@ -1602,11 +1597,9 @@ def gui():
                     for cl in code_content:
                         widget.insert("end", cl + "\n", "code_block")
                     in_code_block = False
-                    code_in_quote = False
                     code_content = []
                 else:
                     in_code_block = True
-                    code_in_quote = is_quote
                 continue
 
             if in_code_block:

--- a/tests/test_auth_settings.py
+++ b/tests/test_auth_settings.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MIT
 
 import json
-import os
 import stat
 import tempfile
 import unittest


### PR DESCRIPTION
Adds three static-analysis passes to CI and fixes what they surface.

## Scanners
- **ruff** (pyflakes `F` rules) and **zizmor** (GitHub Actions security auditor) run in the `ci.yml` static job.
- **CodeQL** (`codeql.yml`, new) scans Python and the native C sources (the DLL injector, cryptbase RNG stub, and XCurl CA shim, cross-compiled with mingw so the extractor observes them).

## Workflow hardening (surfaced by zizmor)
- `persist-credentials: false` on every `actions/checkout` (nothing uses the persisted git token; releases go through `gh` / `softprops`).
- `workflow_dispatch` inputs (`force_rebuild` / `publish` / `channel`) bound to `env:` instead of expanded inline in `run:` blocks (template-injection).
- `codeql-action` pinned to its commit SHA rather than the annotated-tag object.

## Fixes surfaced by ruff (`bol/gui.py`)
- **Bug:** `acct_click()` (and `code_dialog`'s `on_close`) re-imported `msa_signed_in` locally, which shadows the module-level import. In `acct_click` that made the sign-out error path reference `msa_signed_in` before assignment, an `UnboundLocalError` when `msa_logout()` raises. Dropped the redundant local imports.
- Cleanups: removed the unused top-level `from PIL import Image, ImageDraw` (PIL is imported lazily where the QR image is built, so `gui.py` no longer needs Pillow at import time), a redundant local `from .util import load_settings, save_settings`, and a dead `code_in_quote` variable.

## Validation
All checks run green on this PR: ruff, zizmor, and actionlint clean; the test suite, the `pins` guard, and the cryptbase Wine test pass; and CodeQL (Python + the native C) reports 0 alerts.

_Written with Claude Code_
