### PR TITLE
Security: stop sending GITHUB_TOKEN to non-GitHub hosts

### DIFF
--- a/bol/gui.py
+++ b/bol/gui.py
@@ -1996,8 +1996,8 @@ def gui():
             except Exception as e:
                 err_msg = str(e)
                 if "403" in err_msg:
-                    err_msg += ("\n(Rate limit reached. Try setting "
-                                "GITHUB_TOKEN environment variable.)")
+                    err_msg += ("\n(Rate limit reached. This is temporary; the "
+                                "last changelog stays cached. Try again later.)")
                 def _err():
                     tab._is_loading = False
                     show_error(err_msg)

--- a/bol/util.py
+++ b/bol/util.py
@@ -105,10 +105,9 @@ def apply_custom_env(env, custom_env):
 
 
 def http_json(url, timeout=10):
+    # Public read-only endpoints (GitHub releases, Minecraft feedback); no
+    # credentials, so an ambient token can't leak to a non-GitHub host.
     headers = {"User-Agent": APP, "Accept": "application/vnd.github+json"}
-    token = os.environ.get("GITHUB_TOKEN")
-    if token:
-        headers["Authorization"] = f"token {token}"
     req = urllib.request.Request(url, headers=headers)
     with urllib.request.urlopen(req, timeout=timeout) as r:
         return json.loads(r.read().decode())

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,10 +1,39 @@
 """Tests for bol.util's screen-geometry helper."""
 # SPDX-License-Identifier: MIT
 
+import io
+import json
 import unittest
 from unittest import mock
 
 from bol import util
+
+
+class HttpJsonNoCredentialTests(unittest.TestCase):
+    """http_json fetches public endpoints (GitHub releases, Minecraft feedback)
+    from more than one host, so it must never attach a credential, even when
+    GITHUB_TOKEN is present in the environment."""
+
+    def _captured_headers(self, url):
+        captured = {}
+
+        def fake_urlopen(req, timeout=None):
+            captured.update({k.lower(): v for k, v in req.header_items()})
+            return io.BytesIO(json.dumps({"ok": True}).encode())
+
+        with mock.patch.dict("os.environ", {"GITHUB_TOKEN": "SENTINEL_SECRET"}), \
+                mock.patch("urllib.request.urlopen", fake_urlopen):
+            util.http_json(url)
+        return captured
+
+    def test_no_authorization_for_github(self):
+        headers = self._captured_headers("https://api.github.com/repos/x/y/releases")
+        self.assertNotIn("authorization", headers)
+
+    def test_no_authorization_for_non_github(self):
+        headers = self._captured_headers(
+            "https://feedback.minecraft.net/api/v2/help_center/en-us/sections/1/articles.json")
+        self.assertNotIn("authorization", headers)
 
 
 class ScreenWHTests(unittest.TestCase):


### PR DESCRIPTION
## Problem

`bol/util.py`'s `http_json()` reads `GITHUB_TOKEN` from the environment and attaches it as an `Authorization: token ...` header to **every** request. The function fetches two different hosts:

- `api.github.com` (GitHub releases, via `gh_latest` / `gh_releases`)
- `feedback.minecraft.net` (Minecraft game changelog, via `mc_releases`)

So a user or developer with `GITHUB_TOKEN` set in their environment leaks their GitHub credential to `feedback.minecraft.net`. Confirmed with a runtime repro (monkeypatched `urlopen`, `GITHUB_TOKEN` set): the token was sent to both hosts.

## Fix

The token is not required. `http_json` fetches public, read-only data, the changelog already falls back to its on-disk cache on error, and the token only raised GitHub's API rate limit. Rather than patch where the credential travels, this removes the ambient read entirely (principle of least authority): a public read should not consume an environment credential, so there is nothing to leak.

- `bol/util.py`: drop the `GITHUB_TOKEN` read and the `Authorization` header from `http_json`.
- `bol/gui.py`: the 403 handler no longer suggests setting `GITHUB_TOKEN`; it notes the limit is temporary and the last changelog stays cached.
- `tests/test_util.py`: regression test asserting `http_json` sends no `Authorization` header for either an `api.github.com` or a `feedback.minecraft.net` URL, even when `GITHUB_TOKEN` is set.

## Verification

- `python3 -m pytest -q` passes (full suite plus the new tests).
- Re-running the repro against the fixed code: no `Authorization` header is sent to either host.

Fixes #80.

_Written with Claude Code_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
