### PR TITLE
Fix: Settings tabs not scrollable with touchpad/mouse wheel

### DIFF
--- a/bol/gui.py
+++ b/bol/gui.py
@@ -315,6 +315,43 @@ def _geometry_position(geometry):
     return coordinate(match.group(1)), coordinate(match.group(2))
 
 
+def _bind_mousewheel_recursive(widget, target_canvas):
+    """Forward touchpad/mouse-wheel scroll events from any descendant widget
+    to the given scrollable canvas.
+
+    CTkScrollableFrame only reacts to wheel/touchpad events that land
+    directly on its own canvas or scrollbar. Since the frame is normally
+    full of child widgets (labels, switches, entries, buttons), the cursor
+    is almost never over that bare canvas, so scrolling appears "broken".
+    This binds the same handler to the frame and every descendant so a
+    scroll anywhere inside it works.
+    """
+    def _on_wheel(event):
+        # X11 sends Button-4/5 for wheel/touchpad; Windows/macOS send
+        # <MouseWheel> with a signed `delta`.
+        num = getattr(event, "num", None)
+        if num == 4:
+            delta = -1
+        elif num == 5:
+            delta = 1
+        else:
+            delta = -1 if event.delta > 0 else 1
+        try:
+            target_canvas.yview_scroll(delta, "units")
+        except Exception:
+            pass
+        return "break"
+
+    def _bind(w):
+        w.bind("<MouseWheel>", _on_wheel, add="+")
+        w.bind("<Button-4>", _on_wheel, add="+")
+        w.bind("<Button-5>", _on_wheel, add="+")
+        for child in w.winfo_children():
+            _bind(child)
+
+    _bind(widget)
+
+
 class _ThemedMessageBox:
     def __init__(
             self, ctk, tk, root, theme, font, mkbtn, dialog,
@@ -2420,6 +2457,14 @@ def gui():
 
         ctk.CTkLabel(tab_tools, textvariable=imp_status, text_color=T.GOLD,
                      font=font(11)).pack(anchor="w", pady=(6, 0), padx=4)
+
+        # Touchpad/mouse-wheel scrolling: CTkScrollableFrame only reacts when
+        # the cursor is directly over its own (mostly-empty) canvas, so
+        # scrolling appeared broken while hovering the switches/entries/
+        # buttons that fill these tabs. Bind wheel events on every widget
+        # in each tab so scrolling works anywhere inside it.
+        for _sf in (tab_general, tab_advanced, tab_tools):
+            _bind_mousewheel_recursive(_sf, _sf._parent_canvas)
 
     _build_settings()
 


### PR DESCRIPTION
## Problem

The Settings view (General / Advanced / Tools tabs) uses `CTkScrollableFrame`,
but CustomTkinter only binds mousewheel/touchpad scroll events to the
frame's own (mostly empty) canvas — not to the widgets placed inside it.
Since each tab is packed full of labels, switches, entries, and buttons,
the cursor is almost never over that bare canvas, so scrolling appeared
completely broken for touchpad and mouse-wheel users.

## Fix

Added a small helper, `_bind_mousewheel_recursive()`, that walks a widget
and all of its descendants and binds `<MouseWheel>` (Windows/macOS) and
`<Button-4>` / `<Button-5>` (X11 wheel/touchpad) events, forwarding them to
the tab's underlying scrollable canvas via `yview_scroll`.

This is called once at the end of `_build_settings()` for each of the three
tabs (`tab_general`, `tab_advanced`, `tab_tools`), after all their child
widgets have been created.

## Result

Scrolling now works anywhere inside the Settings tabs — hovering a switch,
entry, or button no longer blocks the scroll gesture.

## Testing

- Verified `python3 -m py_compile` passes with no syntax errors.
- Manually confirmed scroll works when hovering various widget types
  (switch, entry, button) inside each Settings tab.

No other behavior was changed.