### PR TITLE
fix: use installation root for profile paths when BOL_HOME is set

### DIFF
--- a/bol/config.py
+++ b/bol/config.py
@@ -103,32 +103,6 @@ def _legacy_install_location_file() -> Path:
     return HOME / ".config" / APP / "install_location"
 
 
-def main_data_root() -> Path:
-    """Return the top-level installation root where profiles/ lives.
-
-    When BOL_HOME points at a sub-profile this ignores it and resolves the
-    installation root from the persistent pointer or DEFAULT_DATA.  When
-    BOL_HOME is not set, returns the same value as DATA.
-    """
-    if os.environ.get("BOL_HOME", "").strip():
-        _data_path = str(DEFAULT_DATA)
-        _pointer_candidates = (INSTALL_LOCATION_FILE,)
-        if LEGACY_INSTALL_LOCATION_FILE != INSTALL_LOCATION_FILE:
-            _pointer_candidates += (LEGACY_INSTALL_LOCATION_FILE,)
-        for _pointer in _pointer_candidates:
-            try:
-                if not _pointer.is_file():
-                    continue
-                _custom_home = _pointer.read_text(encoding="utf-8").strip()
-            except OSError:
-                continue
-            if _custom_home:
-                _data_path = _custom_home
-                break
-        return Path(_data_path).expanduser().resolve()
-    return DATA
-
-
 def get_install_location() -> str:
     """Where the app's data directory currently resolves to."""
     return str(DATA)

--- a/bol/config.py
+++ b/bol/config.py
@@ -103,6 +103,32 @@ def _legacy_install_location_file() -> Path:
     return HOME / ".config" / APP / "install_location"
 
 
+def main_data_root() -> Path:
+    """Return the top-level installation root where profiles/ lives.
+
+    When BOL_HOME points at a sub-profile this ignores it and resolves the
+    installation root from the persistent pointer or DEFAULT_DATA.  When
+    BOL_HOME is not set, returns the same value as DATA.
+    """
+    if os.environ.get("BOL_HOME", "").strip():
+        _data_path = str(DEFAULT_DATA)
+        _pointer_candidates = (INSTALL_LOCATION_FILE,)
+        if LEGACY_INSTALL_LOCATION_FILE != INSTALL_LOCATION_FILE:
+            _pointer_candidates += (LEGACY_INSTALL_LOCATION_FILE,)
+        for _pointer in _pointer_candidates:
+            try:
+                if not _pointer.is_file():
+                    continue
+                _custom_home = _pointer.read_text(encoding="utf-8").strip()
+            except OSError:
+                continue
+            if _custom_home:
+                _data_path = _custom_home
+                break
+        return Path(_data_path).expanduser().resolve()
+    return DATA
+
+
 def get_install_location() -> str:
     """Where the app's data directory currently resolves to."""
     return str(DATA)

--- a/bol/profiles.py
+++ b/bol/profiles.py
@@ -10,7 +10,7 @@ import sys
 import tempfile
 from pathlib import Path
 
-from .config import APP, DATA, PRETTY, XDG_DATA_HOME
+from .config import APP, main_data_root, PRETTY, XDG_DATA_HOME
 from .log import BolError
 
 
@@ -32,7 +32,7 @@ def profile_slug(name):
 
 
 def profiles_root(base_data=None):
-    return Path(base_data or DATA) / "profiles"
+    return Path(base_data or main_data_root()) / "profiles"
 
 
 def _metadata_path(profile_dir):
@@ -67,7 +67,7 @@ def create_profile(name, base_data=None):
     """Create an account/prefix-isolated profile while sharing large assets."""
     display = str(name).strip()
     slug = profile_slug(display)
-    base = Path(base_data or DATA).expanduser().resolve()
+    base = Path(base_data or main_data_root()).expanduser().resolve()
     root = profiles_root(base)
     profile_dir = root / slug
     root.mkdir(parents=True, exist_ok=True)
@@ -124,7 +124,7 @@ def create_profile(name, base_data=None):
 
 
 def list_profiles(base_data=None):
-    root = profiles_root(base_data)
+    root = profiles_root(base_data or main_data_root())
     if not root.is_dir():
         return []
     found = []

--- a/bol/profiles.py
+++ b/bol/profiles.py
@@ -10,7 +10,7 @@ import sys
 import tempfile
 from pathlib import Path
 
-from .config import APP, main_data_root, PRETTY, XDG_DATA_HOME
+from .config import APP, DATA, PRETTY, XDG_DATA_HOME
 from .log import BolError
 
 
@@ -31,12 +31,25 @@ def profile_slug(name):
     return slug
 
 
-def profiles_root(base_data=None):
-    return Path(base_data or main_data_root()) / "profiles"
-
-
 def _metadata_path(profile_dir):
     return Path(profile_dir) / "profile.json"
+
+
+def _profile_base(base_data=None):
+    base = Path(DATA if base_data is None else base_data).expanduser().resolve()
+    if base_data is not None or base.parent.name != "profiles":
+        return base
+    try:
+        metadata = json.loads(_metadata_path(base).read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return base
+    if metadata.get("name") and metadata.get("slug") == base.name:
+        return base.parent.parent
+    return base
+
+
+def profiles_root(base_data=None):
+    return _profile_base(base_data) / "profiles"
 
 
 def _ensure_shared_link(profile_dir, base_data, name):
@@ -67,7 +80,7 @@ def create_profile(name, base_data=None):
     """Create an account/prefix-isolated profile while sharing large assets."""
     display = str(name).strip()
     slug = profile_slug(display)
-    base = Path(base_data or main_data_root()).expanduser().resolve()
+    base = _profile_base(base_data)
     root = profiles_root(base)
     profile_dir = root / slug
     root.mkdir(parents=True, exist_ok=True)
@@ -124,7 +137,7 @@ def create_profile(name, base_data=None):
 
 
 def list_profiles(base_data=None):
-    root = profiles_root(base_data or main_data_root())
+    root = profiles_root(base_data)
     if not root.is_dir():
         return []
     found = []

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -123,6 +123,40 @@ def test_profiles_are_listed_from_metadata(tmp_path):
     assert all(Path(item["path"]).is_dir() for item in items)
 
 
+def test_profile_commands_from_managed_profile_use_sibling_root(tmp_path):
+    base = tmp_path / "data"
+    alice = create_profile("Alice", base)
+
+    with mock.patch("bol.profiles.DATA", alice):
+        bob = create_profile("Bob")
+        items = list_profiles()
+
+    assert bob == base / "profiles" / "bob"
+    assert not (alice / "profiles").exists()
+    assert {item["name"] for item in items} == {"Alice", "Bob"}
+
+
+def test_bol_home_data_root_remains_profile_base(tmp_path):
+    data_root = tmp_path / "direct BOL_HOME"
+
+    with mock.patch("bol.profiles.DATA", data_root):
+        profile = create_profile("Alice")
+        items = list_profiles()
+
+    assert profile == data_root / "profiles" / "alice"
+    assert [item["name"] for item in items] == ["Alice"]
+
+
+def test_explicit_profile_base_overrides_managed_profile_data(tmp_path):
+    current = create_profile("Current", tmp_path / "current")
+    explicit = tmp_path / "explicit"
+
+    with mock.patch("bol.profiles.DATA", current):
+        profile = create_profile("Other", explicit)
+
+    assert profile == explicit / "profiles" / "other"
+
+
 def test_shortcut_uses_isolated_bol_home_and_handles_spaces(tmp_path):
     base = tmp_path / "shared data"
     profile = create_profile("Family Two", base)


### PR DESCRIPTION
When BedrockOnLinux is launched from a managed profile through BOL_HOME, creating or listing profiles must operate on the shared installation root instead of nesting a new profiles/ tree inside the active profile.

The final implementation detects only a valid managed profile directory (profiles/<slug>/profile.json) and then uses its shared parent. A regular BOL_HOME data root and an explicit base_data argument keep their existing semantics.

Validation:

- sibling profile creation and listing from an active managed profile;
- direct BOL_HOME data-root behavior;
- explicit base-root precedence;
- complete CI, native cryptbase test, static checks, pin checks, and Python/C++ CodeQL.