### PR TITLE
fix: avoid stale managed-engine release metadata

### DIFF
--- a/bol/fixups.py
+++ b/bol/fixups.py
@@ -313,7 +313,7 @@ def _install_cryptbase_in_prefix(pfx=None):
     not the game dir, and the OpenSSL XCurl aborts at its first TLS RNG call
     without it. Backs up any existing cryptbase once; idempotent."""
     src = OPENSSL_XCURL_SET / "cryptbase.dll"
-    if not src.exists():
+    if not src.is_file() or src.is_symlink():
         # OpenSSL XCurl set unavailable (download failed, or the rev's asset
         # isn't published yet). Without ANY cryptbase, GDK-Proton's advapi32
         # forward of SystemFunction036 (RtlGenRandom) stays unresolved and the
@@ -326,30 +326,50 @@ def _install_cryptbase_in_prefix(pfx=None):
         from .proton import proton_path
         pp = proton_path()
         builtin = (pp / "files/lib/wine/x86_64-windows/cryptbase.dll") if pp else None
-        if not (builtin and builtin.exists()):
-            return
+        if not (builtin and builtin.is_file() and not builtin.is_symlink()):
+            return False
         src = builtin
     pfx = pfx or active_prefix()
     sys32 = pfx / "drive_c/windows/system32"
     if not sys32.is_dir():
         warn(f"prefix system32 not found at {sys32} — cryptbase stub not "
              "installed (native PlayFab login may fail).")
-        return
+        return False
     dst = sys32 / "cryptbase.dll"
     try:
-        import hashlib
-        if dst.exists() and hashlib.sha1(dst.read_bytes()).digest() == \
-                hashlib.sha1(src.read_bytes()).digest():
-            return
+        source_hash = hashlib.sha256(src.read_bytes()).digest()
+        if dst.is_file() and not dst.is_symlink() and \
+                hashlib.sha256(dst.read_bytes()).digest() == source_hash:
+            return True
         # An existing prefix cryptbase may be a non-functional placeholder —
         # replace it, keeping a one-time backup.
         bak = sys32 / "cryptbase.dll.bol-orig"
-        if dst.exists() and not bak.exists():
-            shutil.copy2(dst, bak)
-        shutil.copy2(src, dst)
+        if (dst.exists() or dst.is_symlink()) and not (
+                bak.exists() or bak.is_symlink()):
+            if dst.is_symlink():
+                bak.symlink_to(os.readlink(dst))
+            elif dst.is_file():
+                shutil.copy2(dst, bak, follow_symlinks=False)
+            else:
+                warn(f"cryptbase install failed: {dst} is not a regular file")
+                return False
+        fd, staged_name = tempfile.mkstemp(
+            prefix=".cryptbase.dll-", dir=sys32)
+        os.close(fd)
+        staged = Path(staged_name)
+        try:
+            shutil.copy2(src, staged, follow_symlinks=False)
+            if hashlib.sha256(staged.read_bytes()).digest() != source_hash:
+                raise BolError(
+                    "cryptbase copy failed integrity checking")
+            os.replace(staged, dst)
+        finally:
+            staged.unlink(missing_ok=True)
         ok("cryptbase RNG stub installed in prefix system32")
+        return True
     except Exception as e:
         warn(f"cryptbase install failed: {e}")
+        return False
 
 
 def _patch_lhc_xcurl_gate(game_dir: Path):

--- a/bol/gamesetup.py
+++ b/bol/gamesetup.py
@@ -117,7 +117,7 @@ _DIAG_RULES = [
      r"forward 'cryptbase\.SystemFunction036'|"
      r"module not found for forward 'cryptbase",
      "Wine RNG unresolved (cryptbase.SystemFunction036) — re-run "
-     "'Install / Update'; the builtin-cryptbase fallback fixes this on relaunch."),
+     "'Install / Update'; setup seeds the verified native RNG before wineboot."),
     (r"nodrv_CreateWindow|no driver could be loaded|"
      r"explorer process failed to start",
      "Wine prefix broken (Wine couldn't open a window)."),

--- a/bol/prefix.py
+++ b/bol/prefix.py
@@ -239,6 +239,66 @@ def prefix_ready(prefix: Path):
     return True
 
 
+def seed_managed_bootstrap_cryptbase(prefix: Path):
+    """Install native cryptbase before managed-prefix services start.
+
+    GDK-Proton's advapi32 forwards SystemFunction036 to cryptbase.  With the
+    managed pure-WoW64 engine, forcing only Wine's builtin cryptbase during an
+    engine upgrade can leave that forward unresolved and make every wineboot
+    service repeatedly abort.  Never materialise or modify an explicitly
+    supplied prefix or a prefix used with a custom engine.
+    """
+    if os.environ.get("BOL_WINEPREFIX", "").strip():
+        return False
+    pfx = Path(prefix)
+    engine = proton_path()
+    if engine is None:
+        return False
+    try:
+        if pfx.resolve(strict=False) != PFX.resolve(strict=False) or \
+                Path(engine).resolve(strict=False) != \
+                WINEGDK_OUT.resolve(strict=False):
+            return False
+    except (OSError, RuntimeError):
+        return False
+
+    if pfx.is_symlink():
+        raise BolError(
+            "The managed Wine prefix is an unsafe symbolic link; "
+            "run Install / Update to rebuild its local layout."
+        )
+    try:
+        pfx.mkdir(parents=True, exist_ok=True)
+        resolved_root = pfx.resolve(strict=True)
+        current = pfx
+        for component in ("drive_c", "windows", "system32"):
+            child = current / component
+            if child.is_symlink():
+                raise BolError(
+                    "The managed Wine prefix has an unsafe system32 layout; "
+                    "run Install / Update to rebuild it."
+                )
+            child.mkdir(exist_ok=True)
+            if not child.is_dir():
+                raise BolError(
+                    "The managed Wine prefix has an invalid system32 layout; "
+                    "run Install / Update to rebuild it."
+                )
+            child.resolve(strict=True).relative_to(resolved_root)
+            current = child
+    except BolError:
+        raise
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise BolError(
+            "The managed Wine prefix has an unsafe system32 layout; "
+            "run Install / Update to rebuild it."
+        ) from exc
+
+    # Import lazily: fixups imports active_prefix from this module.
+    from .fixups import _install_cryptbase_in_prefix
+    return _install_cryptbase_in_prefix(pfx)
+
+
 def boot_prefix(prefix=None):
     """Ensure Wine created system32 and its persistent registry hives."""
     pfx = Path(prefix or active_prefix())
@@ -250,9 +310,10 @@ def boot_prefix(prefix=None):
     from .gpu_safety import require_safe_graphics_session
     require_safe_graphics_session()
     info("Initialising the Wine prefix (first run) …")
+    native_cryptbase = seed_managed_bootstrap_cryptbase(pfx)
     cmd, env = proton_umu_cmd("wineboot", prefix=pfx)
     cmd.append("-u")
-    env = headless_setup_env(env)
+    env = headless_setup_env(env, native_cryptbase=native_cryptbase)
     env.setdefault("WINEDEBUG", "-all")
     LOGS.mkdir(parents=True, exist_ok=True)
     log_path = LOGS / "native-login.log"
@@ -471,7 +532,7 @@ def stop_prefix_procs(prefix: Path, grace=5, kill_grace=2):
     return len(seen), len(forced)
 
 
-def headless_setup_env(env):
+def headless_setup_env(env, native_cryptbase=False):
     """Prevent non-graphical Wine setup helpers from initialising a GPU."""
     result = dict(env)
     result.pop("DISPLAY", None)
@@ -484,9 +545,11 @@ def headless_setup_env(env):
         item for item in result.get("WINEDLLOVERRIDES", "").split(";")
         if item and item.partition("=")[0].strip().lower() not in setup_keys
     ]
-    # wineboot needs Wine's builtin cryptbase for SystemFunction036.  A native
-    # preference here can recurse through advapi32 and leave wineboot spinning.
-    overrides = ["cryptbase=b", "winevulkan=", "dxgi=", "d3d11=", "d3d12="]
+    # Prefer only the verified, self-contained native RNG seeded above. Older
+    # native implementations could recurse through advapi32, so retain the
+    # builtin-only behavior when no safe DLL was staged.
+    cryptbase = "cryptbase=n,b" if native_cryptbase else "cryptbase=b"
+    overrides = [cryptbase, "winevulkan=", "dxgi=", "d3d11=", "d3d12="]
     result["WINEDLLOVERRIDES"] = ";".join(overrides + current)
     return result
 

--- a/bol/winegdk.py
+++ b/bol/winegdk.py
@@ -22,9 +22,7 @@ from .engine_lock import managed_engine_lock
 from .log import die, info, ok, warn
 from .proton import patch_proton
 from .util import (
-    asset_url,
     download,
-    gh_releases,
     load_settings,
     save_settings,
 )
@@ -264,10 +262,11 @@ def _install_prebuilt_winegdk(progress=None, force=False):
 
 def _install_prebuilt_winegdk_locked(progress=None, force=False):
     """Fetch + unpack a prebuilt GDK-Proton-xuser engine so end users never
-    compile a full Wine. Looks for an asset named for the current build rev on
-    the app's own releases, or use BOL_ENGINE_ARCHIVE for an explicit local
-    archive.  The candidate is validated and transactionally activated.  False
-    means no safe replacement was installed; callers may keep the current one."""
+    compile a full Wine. Downloads the asset from the deterministic release tag
+    used by the engine publication workflow, or uses BOL_ENGINE_ARCHIVE for an
+    explicit local archive.  The candidate is validated and transactionally
+    activated.  False means no safe replacement was installed; callers may keep
+    the current one."""
     asset = f"GDK-Proton-xuser-{WINEGDK_BUILD_REV}.tar.gz"
     override = os.environ.get("BOL_ENGINE_ARCHIVE", "").strip()
     if not override:
@@ -295,19 +294,14 @@ def _install_prebuilt_winegdk_locked(progress=None, force=False):
             return False
         info(f"Using local game engine archive: {archive}")
     else:
-        try:
-            rels = gh_releases(WINEGDK_PREBUILT_REPO, 30)
-        except Exception as e:
-            warn(f"Prebuilt engine lookup failed ({e}).")
-            return False
-        url = name = None
-        for rel in rels or []:
-            url, name, _ = asset_url(rel, lambda n: n == asset)
-            if url:
-                break
-        if not url:
-            return False
-        archive = CACHE / name
+        # Engine releases have a stable tag/asset contract.  Addressing that
+        # contract directly avoids the generic release-list cache hiding an
+        # engine published shortly after the launcher metadata was cached.
+        url = (
+            f"https://github.com/{WINEGDK_PREBUILT_REPO}/releases/download/"
+            f"engine-{WINEGDK_BUILD_REV}/{asset}"
+        )
+        archive = CACHE / asset
         if force:
             # A release asset may have been corrected under the same filename;
             # --force must not silently reinstall the stale cached bytes.
@@ -392,10 +386,14 @@ def ensure_winegdk(force=False, progress=None):
     if installed:
         die("Required game engine %s could not be installed. The previous "
             "engine was preserved but is incompatible with this launcher. "
-            "Keep %s beside the AppImage/zipapp and retry." %
+            "Check network access and retry. AppImage/zipapp users can also "
+            "keep %s beside the launcher; Flatpak and packaged-app users "
+            "should retry Install / Update after connectivity is restored." %
             (WINEGDK_BUILD_REV,
              f"GDK-Proton-xuser-{WINEGDK_BUILD_REV}.tar.gz"))
     die("No verified game-engine archive is available for %s. Connect to the "
-        "network and retry, or place %s beside the AppImage/zipapp." %
+        "network and retry. AppImage/zipapp users can also place %s beside "
+        "the launcher; Flatpak and packaged-app users should retry Install / "
+        "Update after connectivity is restored." %
         (WINEGDK_BUILD_REV,
          f"GDK-Proton-xuser-{WINEGDK_BUILD_REV}.tar.gz"))

--- a/tests/test_prefix_safety.py
+++ b/tests/test_prefix_safety.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
-from bol import gameinput, gamesetup, prefix
+from bol import fixups, gameinput, gamesetup, prefix
 from bol.log import BolError
 
 
@@ -77,6 +77,9 @@ class PrefixShutdownTests(unittest.TestCase):
                         prefix, "proton_umu_cmd",
                         return_value=(["umu", "wineboot"], {})) as umu, \
                     mock.patch.object(
+                        prefix, "seed_managed_bootstrap_cryptbase",
+                        return_value=False), \
+                    mock.patch.object(
                         prefix.subprocess, "run",
                         side_effect=finish_prefix) as run, \
                     mock.patch.object(prefix, "stop_prefix_procs"):
@@ -111,6 +114,9 @@ class PrefixShutdownTests(unittest.TestCase):
                         prefix, "proton_umu_cmd",
                         return_value=(["umu", "wineboot"], {})), \
                     mock.patch.object(
+                        prefix, "seed_managed_bootstrap_cryptbase",
+                        return_value=False), \
+                    mock.patch.object(
                         prefix.subprocess, "run",
                         return_value=SimpleNamespace(returncode=42)), \
                     mock.patch.object(prefix, "stop_prefix_procs"), \
@@ -134,6 +140,9 @@ class PrefixShutdownTests(unittest.TestCase):
                         prefix, "proton_umu_cmd",
                         return_value=(["umu", "wineboot"], {})), \
                     mock.patch.object(
+                        prefix, "seed_managed_bootstrap_cryptbase",
+                        return_value=False), \
+                    mock.patch.object(
                         prefix.subprocess, "run",
                         side_effect=prefix.subprocess.TimeoutExpired(
                             ["umu", "wineboot"], 300)), \
@@ -156,6 +165,9 @@ class PrefixShutdownTests(unittest.TestCase):
                     mock.patch.object(
                         prefix, "proton_umu_cmd",
                         return_value=(["umu", "wineboot"], {})), \
+                    mock.patch.object(
+                        prefix, "seed_managed_bootstrap_cryptbase",
+                        return_value=False), \
                     mock.patch.object(
                         prefix.subprocess, "run",
                         side_effect=OSError("cannot execute")), \
@@ -262,6 +274,105 @@ class PrefixEnvironmentTests(unittest.TestCase):
         self.assertNotIn("cryptbase=n,b", overrides)
         self.assertNotIn("dxgi=n", overrides)
 
+    def test_headless_setup_prefers_seeded_native_cryptbase(self):
+        result = prefix.headless_setup_env(
+            {"WINEDLLOVERRIDES": "cryptbase=b;foo=n"},
+            native_cryptbase=True,
+        )
+        overrides = result["WINEDLLOVERRIDES"].split(";")
+
+        self.assertEqual(overrides.count("cryptbase=n,b"), 1)
+        self.assertNotIn("cryptbase=b", overrides)
+        self.assertIn("foo=n", overrides)
+
+    def test_bootstrap_cryptbase_is_seeded_into_fresh_managed_prefix(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            pfx = root / "fresh-prefix"
+            engine = root / "managed-engine"
+            engine.mkdir()
+
+            with mock.patch.dict(prefix.os.environ, {}, clear=True), \
+                    mock.patch.object(prefix, "PFX", pfx), \
+                    mock.patch.object(prefix, "WINEGDK_OUT", engine), \
+                    mock.patch.object(
+                        prefix, "proton_path", return_value=engine), \
+                    mock.patch(
+                        "bol.fixups._install_cryptbase_in_prefix",
+                        return_value=True) as install:
+                self.assertTrue(
+                    prefix.seed_managed_bootstrap_cryptbase(pfx))
+
+            self.assertTrue(
+                (pfx / "drive_c/windows/system32").is_dir())
+            install.assert_called_once_with(pfx)
+
+    def test_bootstrap_cryptbase_never_mutates_explicit_prefix(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            managed = root / "managed-prefix"
+            external = root / "external-prefix"
+            engine = root / "managed-engine"
+            with mock.patch.dict(
+                    prefix.os.environ,
+                    {"BOL_WINEPREFIX": str(external)}, clear=True), \
+                    mock.patch.object(prefix, "PFX", managed), \
+                    mock.patch.object(prefix, "WINEGDK_OUT", engine), \
+                    mock.patch.object(
+                        prefix, "proton_path", return_value=engine), \
+                    mock.patch(
+                        "bol.fixups._install_cryptbase_in_prefix") as install:
+                self.assertFalse(
+                    prefix.seed_managed_bootstrap_cryptbase(external))
+
+            self.assertFalse(external.exists())
+            install.assert_not_called()
+
+    def test_bootstrap_cryptbase_never_mutates_custom_engine_prefix(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            pfx = root / "managed-prefix"
+            managed_engine = root / "managed-engine"
+            custom_engine = root / "custom-engine"
+            with mock.patch.dict(prefix.os.environ, {}, clear=True), \
+                    mock.patch.object(prefix, "PFX", pfx), \
+                    mock.patch.object(
+                        prefix, "WINEGDK_OUT", managed_engine), \
+                    mock.patch.object(
+                        prefix, "proton_path", return_value=custom_engine), \
+                    mock.patch(
+                        "bol.fixups._install_cryptbase_in_prefix") as install:
+                self.assertFalse(
+                    prefix.seed_managed_bootstrap_cryptbase(pfx))
+
+            self.assertFalse(pfx.exists())
+            install.assert_not_called()
+
+    def test_bootstrap_cryptbase_rejects_system32_symlink(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            pfx = root / "managed-prefix"
+            engine = root / "managed-engine"
+            external = root / "external"
+            (pfx / "drive_c/windows").mkdir(parents=True)
+            engine.mkdir()
+            external.mkdir()
+            (pfx / "drive_c/windows/system32").symlink_to(
+                external, target_is_directory=True)
+
+            with mock.patch.dict(prefix.os.environ, {}, clear=True), \
+                    mock.patch.object(prefix, "PFX", pfx), \
+                    mock.patch.object(prefix, "WINEGDK_OUT", engine), \
+                    mock.patch.object(
+                        prefix, "proton_path", return_value=engine), \
+                    mock.patch(
+                        "bol.fixups._install_cryptbase_in_prefix") as install:
+                with self.assertRaisesRegex(BolError, "unsafe system32"):
+                    prefix.seed_managed_bootstrap_cryptbase(pfx)
+
+            self.assertEqual(list(external.iterdir()), [])
+            install.assert_not_called()
+
     def test_proton_umu_uses_neutral_gameid_without_rewriting_steam_identity(
             self):
         cases = [
@@ -325,6 +436,63 @@ class PrefixEnvironmentTests(unittest.TestCase):
                 "Minecraft.Windows.exe", Path("/tmp/prefix"))
 
         self.assertNotIn("PROTON_USE_WOW64", env)
+
+
+class CryptbaseInstallTests(unittest.TestCase):
+    def test_install_is_atomic_and_preserves_existing_file_once(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            source_dir = root / "openssl-set"
+            source_dir.mkdir()
+            (source_dir / "cryptbase.dll").write_bytes(b"verified-rng")
+            pfx = root / "prefix"
+            system32 = pfx / "drive_c/windows/system32"
+            system32.mkdir(parents=True)
+            destination = system32 / "cryptbase.dll"
+            destination.write_bytes(b"old-placeholder")
+
+            with mock.patch.object(
+                    fixups, "OPENSSL_XCURL_SET", source_dir), \
+                    mock.patch.object(fixups, "ok"):
+                self.assertTrue(
+                    fixups._install_cryptbase_in_prefix(pfx))
+                self.assertTrue(
+                    fixups._install_cryptbase_in_prefix(pfx))
+
+            self.assertEqual(destination.read_bytes(), b"verified-rng")
+            self.assertEqual(
+                (system32 / "cryptbase.dll.bol-orig").read_bytes(),
+                b"old-placeholder",
+            )
+            self.assertEqual(
+                list(system32.glob(".cryptbase.dll-*")), [])
+
+    def test_install_replaces_symlink_without_touching_its_target(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            source_dir = root / "openssl-set"
+            source_dir.mkdir()
+            (source_dir / "cryptbase.dll").write_bytes(b"verified-rng")
+            pfx = root / "prefix"
+            system32 = pfx / "drive_c/windows/system32"
+            system32.mkdir(parents=True)
+            external = root / "external-cryptbase.dll"
+            external.write_bytes(b"external")
+            destination = system32 / "cryptbase.dll"
+            destination.symlink_to(external)
+
+            with mock.patch.object(
+                    fixups, "OPENSSL_XCURL_SET", source_dir), \
+                    mock.patch.object(fixups, "ok"):
+                self.assertTrue(
+                    fixups._install_cryptbase_in_prefix(pfx))
+
+            self.assertFalse(destination.is_symlink())
+            self.assertEqual(destination.read_bytes(), b"verified-rng")
+            self.assertEqual(external.read_bytes(), b"external")
+            backup = system32 / "cryptbase.dll.bol-orig"
+            self.assertTrue(backup.is_symlink())
+            self.assertEqual(os.readlink(backup), str(external))
 
 
 class ManagedRuntimeRepairTests(unittest.TestCase):

--- a/tests/test_winegdk.py
+++ b/tests/test_winegdk.py
@@ -181,14 +181,12 @@ class WineGDKInstallTests(unittest.TestCase):
         archive = self._archive(marker="new")
 
         with mock.patch.dict(os.environ, {"BOL_ENGINE_ARCHIVE": str(archive)}), \
-                mock.patch.object(winegdk, "gh_releases") as releases, \
                 mock.patch.object(winegdk, "download") as download:
             installed = winegdk._install_prebuilt_winegdk(force=True)
 
         self.assertTrue(installed)
         self.assertEqual((self.engine / "proton").read_text(), "new")
         self.assertTrue(archive.is_file(), "force must not delete a local archive")
-        releases.assert_not_called()
         download.assert_not_called()
         self.assertEqual(self.validator.call_count, 1)
         self.assertEqual(self.validator.call_args.args[1], self.REV)
@@ -203,15 +201,44 @@ class WineGDKInstallTests(unittest.TestCase):
         with mock.patch.dict(
                 os.environ,
                 {"BOL_ENGINE_ARCHIVE": "", "APPIMAGE": str(appimage)}), \
-                mock.patch.object(winegdk, "gh_releases") as releases, \
                 mock.patch.object(winegdk, "download") as download:
             installed = winegdk._install_prebuilt_winegdk()
 
         self.assertTrue(installed)
         self.assertEqual((self.engine / "proton").read_text(), "sibling-r12")
         self.assertEqual(archive.parent, appimage.parent)
-        releases.assert_not_called()
         download.assert_not_called()
+
+    def test_remote_download_ignores_stale_release_metadata(self):
+        fresh = self._archive(name="fresh.tar.gz", marker="fresh")
+        asset = f"GDK-Proton-xuser-{self.REV}.tar.gz"
+        stale_metadata = self.cache / (
+            "releases_Wyze3306_BedrockOnLinux_30.json")
+        stale_metadata.parent.mkdir(parents=True)
+        stale_metadata.write_text(
+            '[{"tag_name":"engine-old","assets":[]}]',
+            encoding="utf-8",
+        )
+
+        def download_fresh(_url, dest, _label, _progress):
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(fresh, dest)
+
+        with mock.patch.object(
+                winegdk, "download",
+                side_effect=download_fresh) as download:
+            installed = winegdk._install_prebuilt_winegdk()
+
+        self.assertTrue(installed)
+        download.assert_called_once_with(
+            "https://github.com/Wyze3306/BedrockOnLinux/releases/download/"
+            f"engine-{self.REV}/{asset}",
+            self.cache / asset,
+            "Game engine",
+            None,
+        )
+        self.assertEqual((self.engine / "proton").read_text(), "fresh")
+        self.assertTrue(stale_metadata.is_file())
 
     def test_force_deletes_cached_archive_and_downloads_again(self):
         self._write_engine(self.engine, "old")
@@ -221,25 +248,31 @@ class WineGDKInstallTests(unittest.TestCase):
         cached.parent.mkdir(parents=True)
         cached.write_bytes(b"stale cached bytes")
         cached.with_suffix(cached.suffix + ".part").write_bytes(b"stale part")
-        release = {"assets": [{
-            "name": asset,
-            "browser_download_url": "https://example.invalid/" + asset,
-            "size": fresh.stat().st_size,
-        }]}
 
         def download_fresh(_url, dest, _label, _progress):
             dest.parent.mkdir(parents=True, exist_ok=True)
             shutil.copyfile(fresh, dest)
 
-        with mock.patch.object(winegdk, "gh_releases", return_value=[release]), \
-                mock.patch.object(winegdk, "download",
-                                  side_effect=download_fresh) as download:
+        with mock.patch.object(winegdk, "download",
+                               side_effect=download_fresh) as download:
             installed = winegdk._install_prebuilt_winegdk(force=True)
 
         self.assertTrue(installed)
         download.assert_called_once()
         self.assertFalse(cached.with_suffix(cached.suffix + ".part").exists())
         self.assertEqual((self.engine / "proton").read_text(), "fresh")
+
+    def test_remote_download_failure_keeps_current_engine(self):
+        self._write_engine(self.engine, "known-good")
+
+        with mock.patch.object(
+                winegdk, "download",
+                side_effect=OSError("simulated network failure")):
+            installed = winegdk._install_prebuilt_winegdk(force=True)
+
+        self.assertFalse(installed)
+        self.assertEqual((self.engine / "proton").read_text(), "known-good")
+        self.validator.assert_not_called()
 
     def test_manifest_failure_keeps_current_engine(self):
         self._write_engine(self.engine, "known-good")
@@ -422,7 +455,8 @@ class WineGDKInstallTests(unittest.TestCase):
                                   return_value=False) as install, \
                 mock.patch.object(winegdk, "_wire_winegdk",
                                   return_value=self.engine):
-            with self.assertRaises(BolError):
+            with self.assertRaisesRegex(
+                    BolError, "Flatpak and packaged-app users"):
                 winegdk.ensure_winegdk()
 
         install.assert_called_once_with(None, force=False)


### PR DESCRIPTION
## Summary

Fix the managed upgrade path from `wow64-archs-native6` to `wow64-archs-native12`, particularly for Flatpak users.

Two independent failures could prevent the upgrade from completing:

1. A cached GitHub release list created before the new engine was published
   could hide the required archive for up to 12 hours.
2. After the engine was installed, `wineboot` could repeatedly abort because
   `advapi32.SystemFunction036` could not resolve through the builtin-only
   `cryptbase` path, eventually causing the 300-second prefix initialization
   timeout.

## Changes

### Engine download

- Download managed engines from the existing deterministic release path:
  `engine-<revision>/GDK-Proton-xuser-<revision>.tar.gz`.
- Avoid stale generic release metadata hiding newly published engine assets.
- Preserve `BOL_ENGINE_ARCHIVE` and AppImage/zipapp sibling-archive overrides.
- Preserve archive verification, transactional activation, and rollback
  behavior.
- Improve recovery guidance for Flatpak and packaged-app users.

### Wine prefix initialization

- Seed a usable native `cryptbase.dll` before managed-prefix Wine services
  start.
- Use the seeded native implementation with builtin fallback during
  `wineboot`, allowing `advapi32.SystemFunction036` to resolve.
- Restrict this behavior to the verified managed engine and managed prefix.
  Explicit `BOL_WINEPREFIX` and custom-engine configurations remain untouched.
- Reuse the existing cryptbase installer with atomic replacement, integrity
  checking, one-time backup preservation, and symlink-safe handling.
- Retain the conservative builtin-only behavior when a safe native DLL cannot
  be staged.
- Update diagnostic guidance for unresolved Wine RNG failures.

## Safety

- Explicit third-party Wine prefixes are never created or modified by the new
  bootstrap path.
- Custom engines do not trigger managed-prefix repair.
- Symlinked or escaping `system32` layouts are rejected before any DLL is
  installed.
- Existing `cryptbase.dll` files receive a one-time backup before replacement.
- Failed copies cannot leave a partially written destination DLL.

## Testing

- `479 passed, 2 skipped, 53 subtests passed`
- The two remaining skips require the optional system-level `dpkg-deb` tool.
- All Flatpak local-build and payload-audit tests passed after installing
  PyYAML.
- Ruff pyflakes checks passed.
- Python byte-compilation and `git diff --check` passed.
- Confirmed the deterministic `wow64-archs-native12` release URL resolves.
- Confirmed a completely fresh managed prefix initializes successfully inside
  the Flatpak sandbox in approximately eight seconds.
- Confirmed explicit prefixes and custom-engine configurations remain
  untouched.