### PR TITLE
fix: purge Wine refresh token on logout

### DIFF
--- a/bol/auth.py
+++ b/bol/auth.py
@@ -20,7 +20,7 @@ from .config import (
     WINEGDK_REG,
 )
 from .log import BolError, die, err, info, ok, warn
-from .prefix import active_prefix
+from .prefix import active_prefix, prefix_operation_lock
 from .util import http_post_form, load_settings, save_settings
 from .wine_registry import (
     reg_delete,
@@ -76,27 +76,40 @@ def msa_gamertag():
 
 def msa_logout():
     """Forget account credentials without retaining reusable Xbox tokens."""
-    try:
-        # Rotate the account generation, purge Xbox tokens and remove the MSA
-        # refresh token under one lock. An in-flight login/launch either wins
-        # before this block (and is then deleted) or observes the new epoch and
-        # is refused; it can never resurrect the old account afterwards.
-        _purge_account_preauth(MSA_DIR / "token.json")
-        if MSA_DIR.is_dir():
-            try:
-                fd = os.open(MSA_DIR, os.O_RDONLY
-                             | getattr(os, "O_DIRECTORY", 0))
+    with prefix_operation_lock("sign out of Microsoft"):
+        try:
+            # Clear the durable Wine copy first. If this fails, leave the
+            # canonical MSA token and account generation intact so the UI keeps
+            # showing the real state and the user can safely retry.
+            wine_reg_remove_refresh_token()
+        except Exception as exc:
+            raise BolError(
+                "Could not remove the Microsoft login token from the Wine "
+                "prefix; sign-out was cancelled."
+            ) from exc
+
+        try:
+            # Rotate the account generation, purge Xbox tokens and remove the
+            # canonical MSA refresh token under one lock. An in-flight login
+            # either wins before this block (and is then deleted) or observes
+            # the new epoch and is refused; it cannot resurrect the old account.
+            _purge_account_preauth(MSA_DIR / "token.json")
+            if MSA_DIR.is_dir():
                 try:
-                    os.fsync(fd)
-                finally:
-                    os.close(fd)
-            except OSError:
-                pass
-    except Exception as exc:
-        # Fail closed: keeping the current account linked is safer than showing
-        # "signed out" while its old XSTS cache could survive for a new login.
-        raise BolError("Could not safely clear the Microsoft/Xbox account "
-                       "cache; sign-out was cancelled.") from exc
+                    fd = os.open(MSA_DIR, os.O_RDONLY
+                                 | getattr(os, "O_DIRECTORY", 0))
+                    try:
+                        os.fsync(fd)
+                    finally:
+                        os.close(fd)
+                except OSError:
+                    pass
+        except Exception as exc:
+            # The registry token is already gone, but never claim success while
+            # another reusable account cache may remain.
+            raise BolError("Could not safely clear the Microsoft/Xbox account "
+                           "cache; sign-out was cancelled.") from exc
+    ok("Microsoft account signed out from this installation")
     return True
 
 
@@ -1228,6 +1241,26 @@ def wine_reg_set_refresh_token(token):
         warn(f"Could not write WineGDK RefreshToken offline: {type(e).__name__}")
         return False
     ok("In-game login token written to the offline Wine prefix")
+    return True
+
+
+def wine_reg_remove_refresh_token():
+    """Remove WineGDK's durable MSA refresh token from an offline prefix.
+
+    A prefix that has never been booted cannot contain the registry copy and is
+    therefore already clean. Other failures propagate so ``msa_logout`` can
+    fail closed before deleting the canonical account cache.
+    """
+    prefix = active_prefix()
+    system_reg = prefix / "system.reg"
+    try:
+        system_reg.lstat()
+    except FileNotFoundError:
+        return True
+    update_prefix_registry(
+        prefix,
+        machine=[reg_delete(WINEGDK_REG, "RefreshToken")],
+    )
     return True
 
 

--- a/bol/gui.py
+++ b/bol/gui.py
@@ -1448,8 +1448,7 @@ def gui():
             if getattr(acct_btn, "_confirm_out", False):
                 na.stop()
                 try:
-                    with prefix_operation_lock("sign out of Microsoft"):
-                        msa_logout()
+                    msa_logout()
                 except BolError as exc:
                     warn(str(exc))
                     acct_state("in" if msa_signed_in() else "out")

--- a/tests/test_auth_settings.py
+++ b/tests/test_auth_settings.py
@@ -419,10 +419,20 @@ class OnlinePreauthPayloadTests(unittest.TestCase):
             root = Path(td)
             msa = root / "msa"
             cache = root / "winegdk-preauth"
+            prefix = root / "pfx"
             msa.mkdir()
             cache.mkdir()
+            prefix.mkdir()
             (msa / "token.json").write_text(
                 json.dumps({"refresh_token": "old-account"}))
+            (prefix / "system.reg").write_text(
+                "WINE REGISTRY Version 2\n"
+                ";; All keys relative to REGISTRY\\Machine\n\n"
+                "[Software\\\\Wine\\\\WineGDK] 1\n"
+                "#time=1\n"
+                '"RefreshToken"="old-account"\n'
+                '"KeepMe"="yes"\n\n'
+            )
             old_payload = self.payload()
             auth._store_online_preauth(cache / "device.json", old_payload)
             key = b"device-private-key"
@@ -432,7 +442,11 @@ class OnlinePreauthPayloadTests(unittest.TestCase):
             (cache / ".device-crash.tmp").write_text("old account tokens")
 
             with mock.patch.object(auth, "DATA", root), \
-                    mock.patch.object(auth, "MSA_DIR", msa):
+                    mock.patch.object(auth, "MSA_DIR", msa), \
+                    mock.patch.object(auth, "active_prefix",
+                                      return_value=prefix), \
+                    mock.patch.object(auth, "prefix_operation_lock"), \
+                    mock.patch("bol.prefix.require_prefix_idle"):
                 self.assertTrue(auth.msa_logout())
 
             self.assertFalse((msa / "token.json").exists())
@@ -442,6 +456,11 @@ class OnlinePreauthPayloadTests(unittest.TestCase):
             self.assertEqual((cache / "device-id.txt").read_text(), device_id)
             self.assertRegex((cache / ".account-epoch").read_text().strip(),
                              r"^[0-9a-f]{32}$")
+            registry = (prefix / "system.reg").read_text()
+            self.assertNotIn('"RefreshToken"=', registry)
+            self.assertIn('"KeepMe"="yes"', registry)
+            self.assertEqual(
+                stat.S_IMODE((prefix / "system.reg").stat().st_mode), 0o600)
 
             # Even if an old cache is restored after a crash, its legacy epoch
             # cannot be consumed by the next account.
@@ -450,6 +469,95 @@ class OnlinePreauthPayloadTests(unittest.TestCase):
                     mock.patch.object(auth, "warn"), \
                     mock.patch.object(auth, "info"):
                 self.assertFalse(auth.xbl_preauth(""))
+
+    def test_logout_registry_failure_preserves_account_state(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            msa = root / "msa"
+            cache = root / "winegdk-preauth"
+            msa.mkdir()
+            cache.mkdir()
+            token = json.dumps({"refresh_token": "must-survive"})
+            payload = self.payload()
+            epoch = "a" * 32
+            (msa / "token.json").write_text(token)
+            payload["_account_epoch"] = epoch
+            (cache / "device.json").write_text(json.dumps(payload))
+            (cache / ".account-epoch").write_text(epoch + "\n")
+
+            with mock.patch.object(auth, "DATA", root), \
+                    mock.patch.object(auth, "MSA_DIR", msa), \
+                    mock.patch.object(auth, "prefix_operation_lock"), \
+                    mock.patch.object(
+                        auth, "wine_reg_remove_refresh_token",
+                        side_effect=OSError("simulated registry failure")):
+                with self.assertRaisesRegex(
+                        auth.BolError, "Wine prefix; sign-out was cancelled"):
+                    auth.msa_logout()
+
+            self.assertEqual((msa / "token.json").read_text(), token)
+            self.assertTrue((cache / "device.json").is_file())
+            self.assertEqual(
+                (cache / ".account-epoch").read_text(), epoch + "\n")
+
+    def test_logout_lock_failure_changes_no_credential_store(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            msa = root / "msa"
+            msa.mkdir()
+            token = json.dumps({"refresh_token": "must-survive"})
+            (msa / "token.json").write_text(token)
+            registry_clear = mock.Mock()
+            cache_purge = mock.Mock()
+
+            with mock.patch.object(auth, "DATA", root), \
+                    mock.patch.object(auth, "MSA_DIR", msa), \
+                    mock.patch.object(
+                        auth, "prefix_operation_lock",
+                        side_effect=auth.BolError("prefix is active")), \
+                    mock.patch.object(
+                        auth, "wine_reg_remove_refresh_token", registry_clear), \
+                    mock.patch.object(
+                        auth, "_purge_account_preauth", cache_purge):
+                with self.assertRaisesRegex(auth.BolError, "prefix is active"):
+                    auth.msa_logout()
+
+            registry_clear.assert_not_called()
+            cache_purge.assert_not_called()
+            self.assertEqual((msa / "token.json").read_text(), token)
+
+    def test_logout_cache_failure_does_not_restore_registry_token(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            msa = root / "msa"
+            msa.mkdir()
+            (msa / "token.json").write_text(
+                json.dumps({"refresh_token": "still-canonical"}))
+            registry_clear = mock.Mock(return_value=True)
+
+            with mock.patch.object(auth, "DATA", root), \
+                    mock.patch.object(auth, "MSA_DIR", msa), \
+                    mock.patch.object(auth, "prefix_operation_lock"), \
+                    mock.patch.object(
+                        auth, "wine_reg_remove_refresh_token", registry_clear), \
+                    mock.patch.object(
+                        auth, "_purge_account_preauth",
+                        side_effect=OSError("simulated cache failure")):
+                with self.assertRaisesRegex(
+                        auth.BolError, "account cache; sign-out was cancelled"):
+                    auth.msa_logout()
+
+            registry_clear.assert_called_once_with()
+            self.assertTrue((msa / "token.json").is_file())
+
+    def test_remove_registry_token_is_noop_before_prefix_boot(self):
+        with tempfile.TemporaryDirectory() as td:
+            prefix = Path(td) / "not-created"
+            with mock.patch.object(auth, "active_prefix",
+                                   return_value=prefix), \
+                    mock.patch.object(auth, "update_prefix_registry") as update:
+                self.assertTrue(auth.wine_reg_remove_refresh_token())
+            update.assert_not_called()
 
     def test_fallback_rechecks_cache_expiry_after_failed_post(self):
         from datetime import datetime, timezone
@@ -685,6 +793,7 @@ class NativeAuthCancellationTests(unittest.TestCase):
 
             with mock.patch.object(auth, "DATA", root), \
                     mock.patch.object(auth, "MSA_DIR", msa), \
+                    mock.patch.object(auth, "prefix_operation_lock"), \
                     mock.patch.object(auth, "http_post_form",
                                       side_effect=post), \
                     mock.patch.object(auth.time, "sleep"), \


### PR DESCRIPTION
## Summary

Strengthen Microsoft/Xbox sign-out by removing the reusable Microsoft refresh token stored in the Wine registry before clearing the canonical account and Xbox pre-auth caches.

## Changes

- Perform logout while holding the prefix operation lock.
- Remove the Wine registry refresh token before deleting canonical account state.
- Fail closed when the prefix is active or registry cleanup fails.
- Prevent partial cache cleanup from restoring the registry credential.
- Keep unrelated Wine registry values intact.
- Add coverage for successful logout, cleanup failures, locking, and uninitialized prefixes.

## Testing

- 83 focused tests pass.
- Python compilation succeeds.
- `git diff --check` succeeds.

## Known limitation

The current implementation cleans only the active Wine prefix. If one `BOL_HOME` has seeded credentials into multiple custom `BOL_WINEPREFIX` locations, inactive prefixes may retain
reusable refresh tokens.