### PR TITLE
fix: stop exporting GNUTLS_SYSTEM_PRIORITY_FILE — restores Friends worlds over the internet (#48)

### DIFF
--- a/bol/launch.py
+++ b/bol/launch.py
@@ -298,13 +298,24 @@ def _launch_once(lock_fds=()):
     env["MICROSOFT_WINDOWSAPPRUNTIME_BOOTSTRAP_INITIALIZE_SHOWUI"] = "0"
     env["MICROSOFT_WINDOWSAPPRUNTIME_BOOTSTRAP_INITIALIZE_FAILFAST"] = "0"
     env["MICROSOFT_WINDOWSAPPRUNTIME_DEPLOYMENT_INITIALIZE_ONERRORSHOWUI"] = "0"
-    # Azure rejects Wine's TLS 1.3 ClientHello; force TLS 1.2 for this process.
-    prio = DATA / "etc" / "gnutls-no-tls13.cfg"
-    if not prio.exists():
-        prio.parent.mkdir(parents=True, exist_ok=True)
-        prio.write_text("[priorities]\nSYSTEM = NORMAL:-VERS-TLS1.3:%COMPAT\n")
-    env["GNUTLS_SYSTEM_PRIORITY_FILE"] = str(prio)
-    env["GNUTLS_SYSTEM_PRIORITY_FAIL_ON_INVALID"] = "0"
+    # Do NOT set GNUTLS_SYSTEM_PRIORITY_FILE. A previous workaround pointed it
+    # at a "[priorities]\nSYSTEM = NORMAL:-VERS-TLS1.3:%COMPAT" file to force
+    # TLS 1.2, but inside the Flatpak it does the opposite: the runtime's
+    # GnuTLS default priority is not "@SYSTEM", so the file's SYSTEM override
+    # never applies, while the mere presence of the variable makes Wine's
+    # secur32 (set_priority in schannel_gnutls.c) skip its own version-capped
+    # priority string and use raw GnuTLS defaults — negotiating TLS 1.3, which
+    # this Wine's schannel does not support. Result: every in-game WinHTTP TLS
+    # connection to Xbox/Azure edges died post-handshake (0x2746 resets /
+    # 0x80090304 fatal alerts), the XSAPI RTA WebSocket could never connect,
+    # MPSD session writes lacked the required "connection" member, and Friends
+    # worlds failed with the misleading "world is full" error (issue #48).
+    # Wine's own schannel priority already caps at TLS 1.2, achieving what the
+    # workaround intended. Verified with tools/winhttp-rta-probe.c: with the
+    # variable set, 58/66 probes fail (rta.xboxlive.com 100%); without it,
+    # 66/66 succeed.
+    env.pop("GNUTLS_SYSTEM_PRIORITY_FILE", None)
+    env.pop("GNUTLS_SYSTEM_PRIORITY_FAIL_ON_INVALID", None)
     preauth = DATA / "winegdk-preauth" / "device.json"
     if preauth.exists():
         env["WINEGDK_PREAUTH_DEVICE"] = "Z:" + str(preauth).replace("/", "\\")

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -14,7 +14,8 @@ from bol import launch
 class GraphicsEngineLaunchTests(unittest.TestCase):
     def _exercise_ready_launch(self, root, popen, arm, disarm,
                                prefix_idle=True, mark=None, preauth=True,
-                               lock_fds=(), managed_engine=True):
+                               lock_fds=(), managed_engine=True,
+                               umu_env=None):
         content = root / "content"
         logs = root / "logs"
         data = root / "data"
@@ -54,7 +55,7 @@ class GraphicsEngineLaunchTests(unittest.TestCase):
             mock.patch.object(launch, "xbl_preauth", return_value=preauth),
             mock.patch.object(launch, "bump_stack_reserve"),
             mock.patch.object(launch, "proton_umu_cmd",
-                              return_value=(["fake-umu"], {})),
+                              return_value=(["fake-umu"], dict(umu_env or {}))),
             mock.patch.object(launch, "patch_options"),
             mock.patch.object(launch, "diagnose", return_value=[]),
             mock.patch.object(launch, "_prefix_stably_idle_after_wrapper",
@@ -474,6 +475,42 @@ class GraphicsEngineLaunchTests(unittest.TestCase):
         self.assertEqual(env["PROTON_USE_WINED3D"], "0")
         self.assertEqual(env["VKD3D_SHADER_CACHE_PATH"], "0")
         self.assertEqual(env["DXVK_SHADER_CACHE_PATH"], "/custom/dxvk")
+
+    def test_gnutls_priority_override_is_never_exported(self):
+        """Regression for issue #48: exporting GNUTLS_SYSTEM_PRIORITY_FILE
+        makes Wine's secur32 abandon its version-capped GnuTLS priority and
+        negotiate TLS 1.3, which this Wine's schannel does not support. Every
+        in-game WinHTTP TLS connection (including the XSAPI RTA WebSocket that
+        MPSD session writes depend on) then dies post-handshake, and Friends
+        worlds fail with "world is full". The launch environment must not
+        carry the variable, even when it is inherited."""
+        observed = {}
+
+        class Process:
+            @staticmethod
+            def wait(timeout):
+                return 0
+
+        def popen(*_args, **kwargs):
+            observed.update(kwargs)
+            return Process()
+
+        with tempfile.TemporaryDirectory() as td:
+            self._exercise_ready_launch(
+                Path(td),
+                popen,
+                lambda: "owned-token",
+                lambda _token: True,
+                umu_env={
+                    "GNUTLS_SYSTEM_PRIORITY_FILE": "/stale/gnutls.cfg",
+                    "GNUTLS_SYSTEM_PRIORITY_FAIL_ON_INVALID": "0",
+                },
+            )
+
+        self.assertIn("env", observed)
+        self.assertNotIn("GNUTLS_SYSTEM_PRIORITY_FILE", observed["env"])
+        self.assertNotIn("GNUTLS_SYSTEM_PRIORITY_FAIL_ON_INVALID",
+                         observed["env"])
 
     def test_gpu_safety_failure_allows_engine_update_but_blocks_wine(self):
         with tempfile.TemporaryDirectory() as td:

--- a/tools/winhttp-rta-probe.c
+++ b/tools/winhttp-rta-probe.c
@@ -1,0 +1,371 @@
+/*
+ * winhttp-rta-probe — standalone WinHTTP TLS / WebSocket-upgrade probe.
+ *
+ * Purpose (Friends-world investigation, upstream issue #48): test whether
+ * Wine's winhttp/secur32(GnuTLS) stack can complete an HTTPS request and a
+ * WebSocket upgrade handshake against rta.xboxlive.com and related
+ * Azure-fronted hosts, OUTSIDE Minecraft and WITHOUT any credentials.
+ *
+ * Hypothesis under test: Minecraft/XSAPI's RTA WebSocket connect attempts to
+ * wss://rta.xboxlive.com/connect die at the TLS layer (WinHttpReceiveResponse
+ * failing with 0x80090304 / 0x2746, "TLS fatal alert received"), so XSAPI
+ * never obtains an MPSD connection id and the session write is rejected with
+ * HTTP 400 ("world is full").
+ *
+ * The probe sends NO authentication and logs NO identifiers: every request is
+ * an anonymous GET. Expected result on a healthy TLS path is an ordinary HTTP
+ * status (404/401/403/...). A ReceiveResponse failure reproduces the game's
+ * failure mode.
+ *
+ * Usage: winhttp-rta-probe.exe [iterations]
+ * Build: x86_64-w64-mingw32-gcc -O2 -Wall -Wextra -Werror \
+ *          -o winhttp-rta-probe.exe winhttp-rta-probe.c -lwinhttp
+ */
+
+#include <windows.h>
+#include <winhttp.h>
+#include <stdio.h>
+
+#define PROBE_BANNER "winhttp-rta-probe-v1"
+
+#ifndef WINHTTP_OPTION_UPGRADE_TO_WEB_SOCKET
+#define WINHTTP_OPTION_UPGRADE_TO_WEB_SOCKET 114
+#endif
+#ifndef WINHTTP_OPTION_SECURE_PROTOCOLS
+#define WINHTTP_OPTION_SECURE_PROTOCOLS 84
+#endif
+#ifndef WINHTTP_FLAG_SECURE_PROTOCOL_TLS1_2
+#define WINHTTP_FLAG_SECURE_PROTOCOL_TLS1_2 0x00000800
+#endif
+#ifndef WINHTTP_FLAG_SECURE_PROTOCOL_TLS1_3
+#define WINHTTP_FLAG_SECURE_PROTOCOL_TLS1_3 0x00002000
+#endif
+
+/* Relax certificate validation only: a scratch Wine prefix may lack a CA
+ * bundle, and certificate trust is not the layer under test. Record-layer /
+ * alert failures are unaffected by these flags. */
+static const DWORD ignore_cert_flags =
+    SECURITY_FLAG_IGNORE_UNKNOWN_CA |
+    SECURITY_FLAG_IGNORE_CERT_DATE_INVALID |
+    SECURITY_FLAG_IGNORE_CERT_CN_INVALID |
+    SECURITY_FLAG_IGNORE_CERT_WRONG_USAGE;
+
+struct probe_host
+{
+    const WCHAR *host;
+    const WCHAR *path;
+    const char  *label;
+    BOOL         websocket;   /* also attempt a WebSocket upgrade */
+};
+
+static const struct probe_host hosts[] =
+{
+    { L"rta.xboxlive.com",            L"/connect", "rta",       TRUE  },
+    { L"sessiondirectory.xboxlive.com", L"/",      "mpsd",      FALSE },
+    { L"client.discovery.minecraft-services.net", L"/", "discovery", FALSE },
+    /* hosts named by WineGDK HTTPClient.c as failing the in-game cert probe */
+    { L"20ca2.playfabapi.com",        L"/",        "playfab",   FALSE },
+    { L"self.events.data.microsoft.com", L"/",     "events",    FALSE },
+    { L"example.com",                 L"/",        "neutral",   FALSE },
+};
+
+/* Async plumbing: libHttpClient opens its WinHTTP session with
+ * WINHTTP_FLAG_ASYNC and drives the upgrade through status callbacks; Wine's
+ * async request path is distinct code from the sync path, so probe both. */
+struct async_ctx
+{
+    HANDLE done;
+    DWORD  error;        /* 0 = HEADERS_AVAILABLE reached */
+    BOOL   headers;
+};
+
+static void CALLBACK async_callback( HINTERNET handle, DWORD_PTR context,
+                                     DWORD status, LPVOID info, DWORD length )
+{
+    struct async_ctx *ctx = (struct async_ctx *)context;
+    (void)length;
+    if (!ctx) return;
+    switch (status)
+    {
+    case WINHTTP_CALLBACK_STATUS_SENDREQUEST_COMPLETE:
+        /* async flow: request the response from the completion callback,
+         * exactly as libHttpClient's callback_status_sendrequest_complete
+         * does */
+        if (!WinHttpReceiveResponse( handle, NULL ))
+        {
+            ctx->error = GetLastError();
+            SetEvent( ctx->done );
+        }
+        break;
+    case WINHTTP_CALLBACK_STATUS_HEADERS_AVAILABLE:
+        ctx->headers = TRUE;
+        SetEvent( ctx->done );
+        break;
+    case WINHTTP_CALLBACK_STATUS_REQUEST_ERROR:
+    {
+        WINHTTP_ASYNC_RESULT *result = (WINHTTP_ASYNC_RESULT *)info;
+        ctx->error = result ? result->dwError : 1;
+        SetEvent( ctx->done );
+        break;
+    }
+    case WINHTTP_CALLBACK_STATUS_SECURE_FAILURE:
+        /* informational; REQUEST_ERROR follows */
+        break;
+    }
+}
+
+/* Mimic XSAPI's RTA connect headers without any real credentials: XSAPI sends
+ * an Authorization header ~2.5 KB long plus a Signature header. Header size
+ * alone can change server/edge behavior, so replicate the shape. */
+static WCHAR *build_dummy_headers( void )
+{
+    static WCHAR headers[4096];
+    int pos = 0;
+    pos += swprintf( headers + pos, 4096 - pos, L"Authorization: XBL3.0 x=0000000000000000;" );
+    for (int i = 0; i < 2400; i++) headers[pos++] = L'A';
+    pos += swprintf( headers + pos, 4096 - pos, L"\r\nSignature: " );
+    for (int i = 0; i < 140; i++) headers[pos++] = L'B';
+    headers[pos] = 0;
+    return headers;
+}
+
+/* Async WebSocket upgrade attempt mirroring libHttpClient's sequence.
+ * Returns TRUE when the handshake reached HEADERS_AVAILABLE (any status). */
+static BOOL probe_ws_async( const struct probe_host *ph, BOOL websocket,
+                            BOOL big_headers, const char *variant )
+{
+    HINTERNET session = NULL, connect = NULL, request = NULL;
+    struct async_ctx ctx = { 0 };
+    DWORD status = 0, size = sizeof(status), err = 0;
+    const char *stage = "open";
+    BOOL got_status = FALSE;
+
+    ctx.done = CreateEventW( NULL, TRUE, FALSE, NULL );
+    if (!ctx.done) { err = GetLastError(); goto done; }
+
+    session = WinHttpOpen( L"winhttp-rta-probe/1.0",
+                           WINHTTP_ACCESS_TYPE_DEFAULT_PROXY,
+                           WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS,
+                           WINHTTP_FLAG_ASYNC );
+    if (!session) { err = GetLastError(); goto done; }
+
+    stage = "set-callback";
+    if (WinHttpSetStatusCallback( session, async_callback,
+            WINHTTP_CALLBACK_FLAG_ALL_NOTIFICATIONS, 0 )
+        == WINHTTP_INVALID_STATUS_CALLBACK)
+    { err = GetLastError(); goto done; }
+
+    stage = "connect";
+    connect = WinHttpConnect( session, ph->host, INTERNET_DEFAULT_HTTPS_PORT, 0 );
+    if (!connect) { err = GetLastError(); goto done; }
+
+    stage = "open-request";
+    request = WinHttpOpenRequest( connect, L"GET", ph->path, NULL,
+                                  WINHTTP_NO_REFERER,
+                                  WINHTTP_DEFAULT_ACCEPT_TYPES,
+                                  WINHTTP_FLAG_SECURE );
+    if (!request) { err = GetLastError(); goto done; }
+
+    WinHttpSetOption( request, WINHTTP_OPTION_SECURITY_FLAGS,
+                      (LPVOID)&ignore_cert_flags, sizeof(ignore_cert_flags) );
+
+    if (websocket)
+    {
+        stage = "ws-option";
+        if (!WinHttpAddRequestHeaders( request,
+                L"Sec-WebSocket-Protocol: rta.xboxlive.com.V2", (DWORD)-1,
+                WINHTTP_ADDREQ_FLAG_ADD ))
+        { err = GetLastError(); goto done; }
+        if (!WinHttpSetOption( request, WINHTTP_OPTION_UPGRADE_TO_WEB_SOCKET,
+                               NULL, 0 ))
+        { err = GetLastError(); goto done; }
+    }
+    if (big_headers && !WinHttpAddRequestHeaders( request,
+            build_dummy_headers(), (DWORD)-1, WINHTTP_ADDREQ_FLAG_ADD ))
+    { err = GetLastError(); goto done; }
+
+    stage = "send-request";
+    if (!WinHttpSendRequest( request, WINHTTP_NO_ADDITIONAL_HEADERS, 0,
+                             WINHTTP_NO_REQUEST_DATA, 0, 0, (DWORD_PTR)&ctx ))
+    { err = GetLastError(); goto done; }
+
+    stage = "await-headers";
+    if (WaitForSingleObject( ctx.done, 30000 ) != WAIT_OBJECT_0)
+    { err = ERROR_TIMEOUT; goto done; }
+    if (!ctx.headers) { err = ctx.error; goto done; }
+
+    stage = "query-status";
+    if (!WinHttpQueryHeaders( request,
+            WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER,
+            WINHTTP_HEADER_NAME_BY_INDEX, &status, &size,
+            WINHTTP_NO_HEADER_INDEX ))
+    { err = GetLastError(); goto done; }
+
+    got_status = TRUE;
+
+done:
+    if (got_status)
+        printf( "%s %s %s: OK http=%lu\n", PROBE_BANNER, ph->label, variant,
+                status );
+    else
+        printf( "%s %s %s: FAIL stage=%s err=0x%lx\n", PROBE_BANNER, ph->label,
+                variant, stage, err );
+    fflush( stdout );
+
+    if (request) WinHttpCloseHandle( request );
+    if (connect) WinHttpCloseHandle( connect );
+    if (session)
+    {
+        WinHttpSetStatusCallback( session, NULL, 0, 0 );
+        WinHttpCloseHandle( session );
+    }
+    if (ctx.done) CloseHandle( ctx.done );
+    return got_status;
+}
+
+/* One HTTP(S) attempt. If websocket is set, request the upgrade the same way
+ * libHttpClient does (Sec-WebSocket-Protocol + UPGRADE_TO_WEB_SOCKET option).
+ * Returns TRUE when an HTTP status was obtained (TLS path healthy). */
+static BOOL probe_once( const struct probe_host *ph, DWORD secure_protocols,
+                        BOOL websocket, const char *variant )
+{
+    HINTERNET session = NULL, connect = NULL, request = NULL;
+    DWORD status = 0, size = sizeof(status), err = 0;
+    const char *stage = "open";
+    BOOL got_status = FALSE;
+
+    session = WinHttpOpen( L"winhttp-rta-probe/1.0",
+                           WINHTTP_ACCESS_TYPE_DEFAULT_PROXY,
+                           WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0 );
+    if (!session) { err = GetLastError(); goto done; }
+
+    if (secure_protocols)
+    {
+        stage = "set-protocols";
+        if (!WinHttpSetOption( session, WINHTTP_OPTION_SECURE_PROTOCOLS,
+                               &secure_protocols, sizeof(secure_protocols) ))
+        { err = GetLastError(); goto done; }
+    }
+
+    stage = "connect";
+    connect = WinHttpConnect( session, ph->host, INTERNET_DEFAULT_HTTPS_PORT, 0 );
+    if (!connect) { err = GetLastError(); goto done; }
+
+    stage = "open-request";
+    request = WinHttpOpenRequest( connect, L"GET", ph->path, NULL,
+                                  WINHTTP_NO_REFERER,
+                                  WINHTTP_DEFAULT_ACCEPT_TYPES,
+                                  WINHTTP_FLAG_SECURE );
+    if (!request) { err = GetLastError(); goto done; }
+
+    WinHttpSetOption( request, WINHTTP_OPTION_SECURITY_FLAGS,
+                      (LPVOID)&ignore_cert_flags, sizeof(ignore_cert_flags) );
+
+    if (websocket)
+    {
+        stage = "ws-option";
+        if (!WinHttpAddRequestHeaders( request,
+                L"Sec-WebSocket-Protocol: rta.xboxlive.com.V2", (DWORD)-1,
+                WINHTTP_ADDREQ_FLAG_ADD ))
+        { err = GetLastError(); goto done; }
+        if (!WinHttpSetOption( request, WINHTTP_OPTION_UPGRADE_TO_WEB_SOCKET,
+                               NULL, 0 ))
+        { err = GetLastError(); goto done; }
+    }
+
+    stage = "send-request";
+    if (!WinHttpSendRequest( request, WINHTTP_NO_ADDITIONAL_HEADERS, 0,
+                             WINHTTP_NO_REQUEST_DATA, 0, 0, 0 ))
+    { err = GetLastError(); goto done; }
+
+    stage = "receive-response";
+    if (!WinHttpReceiveResponse( request, NULL ))
+    { err = GetLastError(); goto done; }
+
+    stage = "query-status";
+    if (!WinHttpQueryHeaders( request,
+            WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER,
+            WINHTTP_HEADER_NAME_BY_INDEX, &status, &size,
+            WINHTTP_NO_HEADER_INDEX ))
+    { err = GetLastError(); goto done; }
+
+    got_status = TRUE;
+
+    if (websocket && status == 101)
+    {
+        HINTERNET ws = WinHttpWebSocketCompleteUpgrade( request, 0 );
+        if (ws)
+        {
+            printf( "%s %s %s: HTTP 101 + complete-upgrade OK\n",
+                    PROBE_BANNER, ph->label, variant );
+            WinHttpWebSocketClose( ws, 1000 /* NORMAL */, NULL, 0 );
+            WinHttpCloseHandle( ws );
+        }
+        else
+            printf( "%s %s %s: HTTP 101 but complete-upgrade FAILED err=0x%lx\n",
+                    PROBE_BANNER, ph->label, variant, GetLastError() );
+    }
+
+done:
+    if (got_status)
+        printf( "%s %s %s: OK http=%lu\n", PROBE_BANNER, ph->label, variant,
+                status );
+    else
+        printf( "%s %s %s: FAIL stage=%s err=0x%lx\n", PROBE_BANNER, ph->label,
+                variant, stage, err );
+    fflush( stdout );
+
+    if (request) WinHttpCloseHandle( request );
+    if (connect) WinHttpCloseHandle( connect );
+    if (session) WinHttpCloseHandle( session );
+    return got_status;
+}
+
+int main( int argc, char **argv )
+{
+    int iterations = 5, ok = 0, fail = 0;
+    if (argc > 1) iterations = atoi( argv[1] );
+    if (iterations < 1) iterations = 1;
+
+    printf( "%s starting: %d iteration(s), %u host(s)\n",
+            PROBE_BANNER, iterations,
+            (unsigned)(sizeof(hosts) / sizeof(hosts[0])) );
+    fflush( stdout );
+
+    for (int i = 0; i < iterations; i++)
+    {
+        for (size_t h = 0; h < sizeof(hosts) / sizeof(hosts[0]); h++)
+        {
+            const struct probe_host *ph = &hosts[h];
+
+            /* default protocols, plain GET */
+            if (probe_once( ph, 0, FALSE, "get-default" )) ok++; else fail++;
+
+            /* async plain GET (isolates async-vs-websocket effects) */
+            if (probe_ws_async( ph, FALSE, FALSE, "get-async" )) ok++; else fail++;
+
+            /* TLS 1.2 only, plain GET */
+            if (probe_once( ph, WINHTTP_FLAG_SECURE_PROTOCOL_TLS1_2,
+                            FALSE, "get-tls12" )) ok++; else fail++;
+
+            if (ph->websocket)
+            {
+                /* WebSocket upgrade, default protocols, sync */
+                if (probe_once( ph, 0, TRUE, "ws-default" )) ok++; else fail++;
+
+                /* WebSocket upgrade, TLS 1.2 only, sync */
+                if (probe_once( ph, WINHTTP_FLAG_SECURE_PROTOCOL_TLS1_2,
+                                TRUE, "ws-tls12" )) ok++; else fail++;
+
+                /* WebSocket upgrade, async (libHttpClient's mode) */
+                if (probe_ws_async( ph, TRUE, FALSE, "ws-async" )) ok++; else fail++;
+
+                /* WebSocket upgrade, async + XSAPI-shaped auth header block */
+                if (probe_ws_async( ph, TRUE, TRUE, "ws-async-hdrs" )) ok++; else fail++;
+            }
+        }
+    }
+
+    printf( "%s finished: ok=%d fail=%d\n", PROBE_BANNER, ok, fail );
+    return fail ? 1 : 0;
+}


### PR DESCRIPTION
Fixes #48 — both joining a friend's world ("The world you are trying to join is full") and hosting (Linux-hosted worlds only ever appeared as LAN worlds).

## Root cause

The launcher exported `GNUTLS_SYSTEM_PRIORITY_FILE` pointing at a config with
`SYSTEM = NORMAL:-VERS-TLS1.3:%COMPAT`, intending to force TLS 1.2 for Azure-fronted
hosts. Inside the Flatpak this backfires twice over:

- The freedesktop runtime's GnuTLS default priority is **not** `@SYSTEM`, so the
  file's override never applies.
- The mere presence of the variable makes Wine's secur32 (`set_priority` in
  `dlls/secur32/schannel_gnutls.c`) skip its own version-capped priority string and
  call `gnutls_set_default_priority()` instead — negotiating **TLS 1.3**, which
  Wine 11.1's schannel does not support (its protocol table has no TLS 1.3 entry;
  traces show `fixme: unknown protocol 5`).

Result: every in-game **WinHTTP** TLS connection died right after the handshake
(`0x2746` connection resets / `0x80090304` fatal alerts) — even to neutral hosts.
Traffic over XCurl (OpenSSL libcurl) was unaffected, which is why sign-in, Realms,
and public servers kept working while Friends worlds didn't.

### Why that surfaces as "world is full"

XSAPI's Real-Time Activity WebSocket (`wss://rta.xboxlive.com/connect`) runs over
WinHTTP, so it could never connect. XSAPI signs a fresh token per attempt and after
the 4th consecutive failure flips its RTA state to Disconnected, releasing the queued
MPSD session write **without** an RTA connection id. The serializer then omits
`members.me.properties.system.connection`, MPSD rejects the handle-session PUT with
HTTP 400 "connection required for active members", and Minecraft surfaces that as
"world is full" when joining — and as LAN-only publishing when hosting. The same
defect broke the XNetworking cert probes and other WinHTTP TLS flows.

## Fix

Don't export the variable (and pop any inherited value). Wine's own schannel
priority already caps at TLS 1.2, achieving exactly what the workaround intended —
in every environment, not just ones whose GnuTLS default happens to be `@SYSTEM`.

## Verification

- **New probe tool** `tools/winhttp-rta-probe.c` (anonymous, credential-free WinHTTP
  GETs + WebSocket upgrades against rta/MPSD/PlayFab/discovery/neutral hosts, run
  under the installed engine's Wine in a scratch prefix): with the variable set,
  **58/66 probes fail** inside the Flatpak (`rta.xboxlive.com` 100%, every WebSocket
  upgrade variant); without it, **66/66 succeed**.
- **Attended end-to-end** on a previously-failing setup: joining a Windows 11-hosted
  Friends world now works; hosting on Linux now publishes as a joinable Friends world
  on the Windows machine (was LAN-only); external servers unaffected. Privacy-safe
  captures show the RTA WebSocket connecting on the first attempt (previously 4
  failed attempts per join) and the MPSD handle-session PUT going **400 → 200**.
- **Regression test** (`test_gnutls_priority_override_is_never_exported`) verified
  red against the old code, green against the fix. Full suite: 494 passed,
  53 subtests.
- Realms not retested (no subscription available), but Realms rides the unaffected
  XCurl path.

## Distribution coverage

All three packagings ship the same `bol/` launcher, so the change applies uniformly;
what varies is the host GnuTLS that Wine loads:

- **Flatpak**: was broken, now fixed (verified end-to-end).
- **deb/AppImage on Fedora-family hosts** (GnuTLS default `@SYSTEM`): the old
  workaround genuinely applied there — probe passes both before and after the change
  on such a host, so no regression; the fix just replaces the file-based TLS 1.2 cap
  with Wine's built-in one.
- **deb/AppImage on Debian/Ubuntu-family hosts** (GnuTLS default `NORMAL`): had the
  same broken semantics as the Flatpak, so those users were likely affected too and
  are fixed by this change. The probe tool is in-tree if anyone wants to verify a
  specific distro.

Existing installs keep an inert `etc/gnutls-no-tls13.cfg` on disk; nothing reads it
anymore. Left in place to keep the diff minimal.

## Workaround for users on current releases

Add `GNUTLS_SYSTEM_PRIORITY_FILE=/dev/null` to the custom environment variables in
settings. Wine treats `/dev/null` as "no override", and custom env has final
precedence — verified working with the stock Flatpak.