### PR TITLE
Fix stack reserve exception handling, Zip Slip extraction vulnerability, and QR code GUI threading

### DIFF
--- a/bol/content.py
+++ b/bol/content.py
@@ -6,7 +6,7 @@ import os
 import re
 import shutil
 import zipfile
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 from .log import die, ok, warn
 from .prefix import _mc_running, active_prefix
@@ -98,6 +98,10 @@ def import_content(src, prefix=None):
         dest = _unique_path(base / sub / _safe_component(stem))
         dest.mkdir(parents=True, exist_ok=True)
         with zipfile.ZipFile(src) as z:
+            for m in z.infolist():
+                p = PurePosixPath(m.filename)
+                if p.is_absolute() or ".." in p.parts:
+                    raise ValueError(f"unsafe path in zip archive: {m.filename}")
             z.extractall(dest)
         kind = "world" if ext == ".mcworld" else "world template"
         results.append(f"{kind}: {dest.name}")
@@ -109,6 +113,10 @@ def import_content(src, prefix=None):
     tmp.mkdir(parents=True, exist_ok=True)
     try:
         with zipfile.ZipFile(src) as z:
+            for m in z.infolist():
+                p = PurePosixPath(m.filename)
+                if p.is_absolute() or ".." in p.parts:
+                    raise ValueError(f"unsafe path in zip archive: {m.filename}")
             z.extractall(tmp)
         manifests = sorted(tmp.rglob("manifest.json"),
                            key=lambda p: len(p.parts))

--- a/bol/fixups.py
+++ b/bol/fixups.py
@@ -436,7 +436,7 @@ def bump_stack_reserve(exe: Path, target=0x1000000):
             f.write(struct.pack("<Q", target))
         ok(f"Stack reserve raised {cur // 1024} KB → {target // 1024} KB "
            "(settings/pause crash fix)")
-    except OSError as e:                           # never block a launch over this
+    except (OSError, struct.error, IndexError) as e: # never block a launch over this
         warn(f"Could not raise the stack reserve: {e}")
 
 

--- a/bol/gui.py
+++ b/bol/gui.py
@@ -1578,10 +1578,10 @@ def gui():
                         if qr.get_module(x, y):
                             pixels[x + border, y + border] = 0
                 img = img.resize((150, 150), Image.Resampling.NEAREST).convert("RGB")
-                ctk_img = ctk.CTkImage(light_image=img, dark_image=img, size=(150, 150))
                 def _apply_qr():
                     if not qr_frame.winfo_exists():
                         return
+                    ctk_img = ctk.CTkImage(light_image=img, dark_image=img, size=(150, 150))
                     qr_lbl._is_loaded = True
                     qr_lbl.destroy()
                     ctk.CTkLabel(qr_frame, text="", image=ctk_img).pack(expand=True, fill="both")


### PR DESCRIPTION
Resolves three runtime and security issues:
1. Catches `struct.error` and `IndexError` in `bump_stack_reserve` so non-standard PE headers no longer abort the game launch sequence.
2. Validates member filenames against Zip Slip path traversal when extracting user-imported content archives in `import_content`.
3. Defers `CTkImage` object instantiation in the QR code loader to the main GUI thread, preventing thread-safety crashes in Tcl/Tk.