### PR TITLE
Build the Flatpak with --release so bundles keep their appstream data

### DIFF
--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -197,7 +197,7 @@ if command -v flatpak-builder >/dev/null \
     || { command -v flatpak >/dev/null \
          && flatpak info org.flatpak.Builder >/dev/null 2>&1; }; then
   FLATPAK_LOG="$OUT/flatpak-build.log"
-  if bash "$SRC/scripts/build-flatpak.sh" >"$FLATPAK_LOG" 2>&1 \
+  if bash "$SRC/scripts/build-flatpak.sh" --release >"$FLATPAK_LOG" 2>&1 \
       && [[ -s "$FLATPAK" ]]; then
     echo "  ✓ dist/$(basename "$FLATPAK")"
     built_artifacts+=("$FLATPAK")


### PR DESCRIPTION
Fixes #96

Flatpak packages since v2.1.0 do not contain appstream data, which breaks parental controls (the app is listed as "unknown" for every OARS category).

Note: `--release` requires the manifest's pinned tag to match the version being built, so the pin needs bumping per release. Nightly builds from a moving commit and would need the metainfo retained in the dev path instead.