### PR TITLE
Pin the Flatpak manifest to v2.1.1

### DIFF
--- a/flatpak/io.github.wyze3306.BedrockOnLinux.yml
+++ b/flatpak/io.github.wyze3306.BedrockOnLinux.yml
@@ -196,5 +196,5 @@ modules:
       #   git rev-parse vX.Y.Z^{commit}
       - type: git
         url: https://github.com/Wyze3306/BedrockOnLinux.git
-        tag: v2.0.0
-        commit: 6e929009f43deb0c35730ac5f0031ac179e7f53e
+        tag: v2.1.1
+        commit: ec961ba9024c0d62bf2b793cc2ebba2958147627


### PR DESCRIPTION
Fixes #96. Relates to #141.

The Flatpak manifest still pins v2.0.0 while [`bol/config.py`](https://github.com/Wyze3306/BedrockOnLinux/blob/main/bol/config.py#L9) is at 2.1.1, so the `--release` build from #141 will fail.

The Flatpak manifest pin must be updated to track the current release config's version.
