### PR TITLE
fix: refresh managed-prefix system DLLs on engine upgrade

### DIFF
--- a/bol/prefix.py
+++ b/bol/prefix.py
@@ -29,11 +29,23 @@ from .config import (
     UMU_REPO,
     UMU_RUN_SHA256,
     UMU_VERSION,
+    WINEGDK_BUILD_REV,
     WINEGDK_OUT,
 )
 from .log import BolError, die, info, ok, warn
 from .proton import proton_path
 from .util import download
+
+# Records the engine revision a managed prefix was last built/refreshed with,
+# so an engine upgrade can refresh the prefix's cached Windows system DLLs
+# instead of running the new runtime against a stale, mixed prefix.
+ENGINE_REV_MARKER = ".bol-engine-rev"
+
+# Engine DLL directory -> prefix system directory it populates.
+_MANAGED_RUNTIME_ARCH_DIRS = (
+    ("files/lib/wine/x86_64-windows", "drive_c/windows/system32"),
+    ("files/lib/wine/i386-windows", "drive_c/windows/syswow64"),
+)
 
 def ensure_umu(force=False):
     binp = UMU_DIR / "umu-run"
@@ -387,6 +399,11 @@ def boot_prefix(prefix=None):
     pfx = Path(prefix or active_prefix())
     _prepare_managed_prefix_layout(pfx)
     if prefix_ready(pfx):
+        if managed_prefix_engine_is_stale(pfx):
+            # The engine changed since this prefix was built; its cached
+            # Windows system DLLs no longer match the managed runtime.
+            refresh_managed_prefix_runtime(pfx)
+            _record_managed_engine_rev_if_managed(pfx)
         repair_managed_prefix_user32(pfx)
         return True
     # Refuse a known-bad graphics session before Wine can open a device.
@@ -405,6 +422,7 @@ def boot_prefix(prefix=None):
             while time.time() < end and not prefix_ready(pfx):
                 time.sleep(1)
             if prefix_ready(pfx):
+                _record_managed_engine_rev_if_managed(pfx)
                 repair_managed_prefix_user32(pfx)
                 return True
         if retried or not _wineboot_hit_rng_abort(log_path, attempt_offset):
@@ -549,6 +567,162 @@ def repair_managed_prefix_user32(prefix=None):
         staged.unlink(missing_ok=True)
     ok("Managed Wine runtime repaired (user32.dll).")
     return True
+
+
+def _managed_runtime_guards(pfx, engine):
+    """True only for the managed prefix paired with the managed engine."""
+    if os.environ.get("BOL_WINEPREFIX", "").strip():
+        return False
+    if engine is None:
+        return False
+    try:
+        return Path(pfx).resolve(strict=False) == PFX.resolve(strict=False) \
+            and Path(engine).resolve(strict=False) == \
+            WINEGDK_OUT.resolve(strict=False)
+    except (OSError, RuntimeError):
+        return False
+
+
+def _engine_rev_marker(pfx):
+    return Path(pfx) / ENGINE_REV_MARKER
+
+
+def read_managed_engine_rev(pfx):
+    """Return the engine revision recorded in the prefix, or None."""
+    try:
+        return _engine_rev_marker(pfx).read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+
+
+def _write_managed_engine_rev(pfx, rev):
+    try:
+        _engine_rev_marker(pfx).write_text(rev + "\n", encoding="utf-8")
+    except OSError:
+        pass
+
+
+def _record_managed_engine_rev_if_managed(pfx):
+    if _managed_runtime_guards(pfx, proton_path()):
+        _write_managed_engine_rev(pfx, WINEGDK_BUILD_REV)
+
+
+def managed_prefix_engine_is_stale(prefix=None):
+    """Whether the managed prefix was built by a different engine revision.
+
+    A missing marker counts as stale so installs upgraded in place (whose
+    prefix predates the marker) are refreshed once. Custom prefixes and custom
+    engines are never considered stale and are left untouched.
+    """
+    pfx = Path(prefix or PFX)
+    if not _managed_runtime_guards(pfx, proton_path()):
+        return False
+    return read_managed_engine_rev(pfx) != WINEGDK_BUILD_REV
+
+
+def _dll_differs(source, target):
+    if target.is_symlink() or not target.is_file():
+        return True
+    try:
+        return _sha256_path(target) != _sha256_path(source)
+    except OSError:
+        return True
+
+
+def _replace_managed_dll(source, target):
+    """Atomically refresh one prefix DLL from the engine; return if changed."""
+    source_hash = _sha256_path(source)
+    if target.is_file() and not target.is_symlink():
+        try:
+            if _sha256_path(target) == source_hash:
+                return False
+        except OSError:
+            pass
+    backup = target.with_name(target.name + ".bol-runtime-backup")
+    if not (backup.exists() or backup.is_symlink()):
+        if target.is_symlink():
+            backup.symlink_to(os.readlink(target))
+        elif target.exists():
+            if not target.is_file():
+                raise BolError(
+                    "The managed prefix has a non-regular runtime file: "
+                    "%s" % target.name)
+            shutil.copy2(target, backup, follow_symlinks=False)
+    fd, staged_name = tempfile.mkstemp(
+        prefix=".bol-runtime-", dir=target.parent)
+    os.close(fd)
+    staged = Path(staged_name)
+    try:
+        shutil.copy2(source, staged, follow_symlinks=False)
+        if _sha256_path(staged) != source_hash:
+            raise BolError(
+                "The managed runtime refresh failed integrity checking for "
+                "%s." % target.name)
+        os.replace(staged, target)
+    finally:
+        staged.unlink(missing_ok=True)
+    return True
+
+
+def refresh_managed_prefix_runtime(prefix=None):
+    """Refresh the managed prefix's Windows system DLLs from the engine.
+
+    An engine upgrade swaps the WineGDK tree but reuses the existing prefix,
+    whose cached system32/syswow64 DLLs were populated by the previous engine.
+    Running the new pure-WoW64 runtime against those stale DLLs faults
+    Minecraft's account/menu path with an unhandled page fault (issue #135).
+    Copy every DLL the current engine ships over the prefix's existing system
+    DLLs, leaving the user profile (drive_c/users — worlds, settings, login)
+    untouched. Only the managed prefix on the managed engine is modified.
+    """
+    engine = proton_path()
+    pfx = Path(prefix or PFX)
+    if not _managed_runtime_guards(pfx, engine):
+        return False
+    if pfx.is_symlink():
+        raise BolError(
+            "The managed Wine prefix is an unsafe symbolic link; "
+            "run Install / Update to rebuild its local layout.")
+    try:
+        resolved_root = pfx.resolve(strict=True)
+        operations = []
+        for engine_rel, prefix_rel in _MANAGED_RUNTIME_ARCH_DIRS:
+            src_dir = Path(engine) / engine_rel
+            dst_dir = pfx / prefix_rel
+            if not src_dir.is_dir() or not dst_dir.is_dir():
+                continue
+            if dst_dir.is_symlink():
+                raise BolError(
+                    "The managed Wine prefix has an unsafe system link; "
+                    "run Install / Update to rebuild it.")
+            dst_dir.resolve(strict=True).relative_to(resolved_root)
+            # Deliberate boundary: only refresh DLLs the prefix ALREADY has.
+            # The engine's windows dir holds Wine's full builtin set; a
+            # prefix's system dir is the subset wineboot installed, and Wine
+            # loads the rest straight from the engine dir. Injecting
+            # engine-only DLLs here would disturb that redirection, so a DLL
+            # the prefix lacks is intentionally left absent (issue #135).
+            for source in sorted(src_dir.glob("*.dll")):
+                target = dst_dir / source.name
+                if (target.exists() or target.is_symlink()) \
+                        and _dll_differs(source, target):
+                    operations.append((source, target))
+    except BolError:
+        raise
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise BolError(
+            "The managed Wine prefix has an unsafe system layout; "
+            "run Install / Update to rebuild it.") from exc
+
+    if not operations:
+        return False
+    require_prefix_idle(pfx, "refresh the managed Wine runtime")
+    changed = False
+    for source, target in operations:
+        changed |= _replace_managed_dll(source, target)
+    if changed:
+        ok("Managed Wine runtime refreshed to %s." % WINEGDK_BUILD_REV)
+    return changed
 
 
 def stop_prefix_procs(prefix: Path, grace=5, kill_grace=2):

--- a/tests/test_prefix_safety.py
+++ b/tests/test_prefix_safety.py
@@ -809,6 +809,204 @@ class ManagedRuntimeRepairTests(unittest.TestCase):
             self.assertEqual(target.read_bytes(), b"corrupt-user32")
 
 
+class ManagedRuntimeRefreshTests(unittest.TestCase):
+    """Engine upgrades must refresh the prefix's cached Windows system DLLs.
+
+    Swapping the WineGDK engine while reusing a prefix built by the previous
+    engine leaves stale system32/syswow64 DLLs that fault Minecraft's
+    account/menu path under the pure-WoW64 runtime (issue #135)."""
+
+    def _runtime_paths(self, root, marker_rev="__absent__"):
+        engine = root / "engine"
+        pfx = root / "prefix"
+        e64 = engine / "files/lib/wine/x86_64-windows"
+        e32 = engine / "files/lib/wine/i386-windows"
+        e64.mkdir(parents=True)
+        e32.mkdir(parents=True)
+        (e64 / "user32.dll").write_bytes(b"new-user32-64")
+        (e64 / "ntdll.dll").write_bytes(b"new-ntdll-64")
+        (e32 / "user32.dll").write_bytes(b"new-user32-32")
+        _make_ready_prefix(pfx)
+        sys32 = pfx / "drive_c/windows/system32"
+        wow = pfx / "drive_c/windows/syswow64"
+        wow.mkdir(parents=True, exist_ok=True)
+        (sys32 / "user32.dll").write_bytes(b"old-user32-64")
+        (sys32 / "ntdll.dll").write_bytes(b"old-ntdll-64")
+        (wow / "user32.dll").write_bytes(b"old-user32-32")
+        users = (pfx / "drive_c/users/steamuser/AppData/Roaming/"
+                 "Minecraft Bedrock")
+        users.mkdir(parents=True)
+        (users / "worlds.mcworld").write_bytes(b"precious-world")
+        if marker_rev != "__absent__":
+            (pfx / prefix.ENGINE_REV_MARKER).write_text(marker_rev + "\n")
+        return engine, pfx
+
+    def _managed(self, engine, pfx):
+        return mock.patch.dict(prefix.os.environ, {}, clear=True), \
+            mock.patch.object(prefix, "PFX", pfx), \
+            mock.patch.object(prefix, "WINEGDK_OUT", engine), \
+            mock.patch.object(prefix, "proton_path", return_value=engine)
+
+    def test_engine_upgrade_refreshes_stale_system_dlls(self):
+        with tempfile.TemporaryDirectory() as td:
+            engine, pfx = self._runtime_paths(Path(td))
+            m = self._managed(engine, pfx)
+            with m[0], m[1], m[2], m[3], \
+                    mock.patch.object(prefix, "require_prefix_idle") as idle, \
+                    mock.patch.object(prefix, "ok"):
+                changed = prefix.refresh_managed_prefix_runtime(pfx)
+
+            self.assertTrue(changed)
+            sys32 = pfx / "drive_c/windows/system32"
+            wow = pfx / "drive_c/windows/syswow64"
+            self.assertEqual((sys32 / "user32.dll").read_bytes(),
+                             b"new-user32-64")
+            self.assertEqual((sys32 / "ntdll.dll").read_bytes(),
+                             b"new-ntdll-64")
+            self.assertEqual((wow / "user32.dll").read_bytes(),
+                             b"new-user32-32")
+            self.assertEqual(
+                (sys32 / "user32.dll.bol-runtime-backup").read_bytes(),
+                b"old-user32-64")
+            idle.assert_called_once_with(
+                pfx, "refresh the managed Wine runtime")
+            self.assertEqual(list(sys32.glob(".bol-runtime-*")), [])
+            # The user profile (worlds, settings, login) is preserved.
+            self.assertEqual(
+                (pfx / "drive_c/users/steamuser/AppData/Roaming/"
+                 "Minecraft Bedrock/worlds.mcworld").read_bytes(),
+                b"precious-world")
+
+    def test_matching_runtime_is_untouched(self):
+        with tempfile.TemporaryDirectory() as td:
+            engine, pfx = self._runtime_paths(Path(td))
+            sys32 = pfx / "drive_c/windows/system32"
+            wow = pfx / "drive_c/windows/syswow64"
+            (sys32 / "user32.dll").write_bytes(b"new-user32-64")
+            (sys32 / "ntdll.dll").write_bytes(b"new-ntdll-64")
+            (wow / "user32.dll").write_bytes(b"new-user32-32")
+            m = self._managed(engine, pfx)
+            with m[0], m[1], m[2], m[3], \
+                    mock.patch.object(prefix, "require_prefix_idle") as idle:
+                changed = prefix.refresh_managed_prefix_runtime(pfx)
+
+            self.assertFalse(changed)
+            idle.assert_not_called()
+            self.assertFalse(
+                (sys32 / "user32.dll.bol-runtime-backup").exists())
+
+    def test_custom_engine_and_external_prefix_are_never_refreshed(self):
+        with tempfile.TemporaryDirectory() as td:
+            engine, pfx = self._runtime_paths(Path(td))
+            custom = Path(td) / "custom-engine"
+            external = Path(td) / "external-prefix"
+            with mock.patch.dict(prefix.os.environ, {}, clear=True), \
+                    mock.patch.object(prefix, "PFX", pfx), \
+                    mock.patch.object(prefix, "WINEGDK_OUT", engine), \
+                    mock.patch.object(prefix, "proton_path",
+                                      return_value=custom):
+                self.assertFalse(prefix.refresh_managed_prefix_runtime(pfx))
+            with mock.patch.dict(prefix.os.environ, {}, clear=True), \
+                    mock.patch.object(prefix, "PFX", pfx), \
+                    mock.patch.object(prefix, "WINEGDK_OUT", engine), \
+                    mock.patch.object(prefix, "proton_path",
+                                      return_value=engine):
+                self.assertFalse(
+                    prefix.refresh_managed_prefix_runtime(external))
+            with mock.patch.dict(prefix.os.environ,
+                                 {"BOL_WINEPREFIX": str(external)},
+                                 clear=True), \
+                    mock.patch.object(prefix, "PFX", pfx), \
+                    mock.patch.object(prefix, "WINEGDK_OUT", engine), \
+                    mock.patch.object(prefix, "proton_path",
+                                      return_value=engine):
+                self.assertFalse(prefix.refresh_managed_prefix_runtime(pfx))
+
+            self.assertEqual(
+                (pfx / "drive_c/windows/system32/user32.dll").read_bytes(),
+                b"old-user32-64")
+
+    def test_managed_prefix_engine_is_stale(self):
+        with tempfile.TemporaryDirectory() as td:
+            engine, pfx = self._runtime_paths(Path(td))
+            m = self._managed(engine, pfx)
+            with m[0], m[1], m[2], m[3]:
+                # Missing marker (in-place upgrade) counts as stale.
+                self.assertTrue(prefix.managed_prefix_engine_is_stale(pfx))
+                (pfx / prefix.ENGINE_REV_MARKER).write_text(
+                    "wow64-archs-native6\n")
+                self.assertTrue(prefix.managed_prefix_engine_is_stale(pfx))
+                (pfx / prefix.ENGINE_REV_MARKER).write_text(
+                    prefix.WINEGDK_BUILD_REV + "\n")
+                self.assertFalse(prefix.managed_prefix_engine_is_stale(pfx))
+
+    def test_boot_prefix_refreshes_and_records_marker_on_engine_change(self):
+        with tempfile.TemporaryDirectory() as td:
+            engine, pfx = self._runtime_paths(Path(td))
+            compat = Path(td) / "compatdata"
+            m = self._managed(engine, pfx)
+            with m[0], m[1], m[2], m[3], \
+                    mock.patch.object(prefix, "COMPAT", compat), \
+                    mock.patch.object(prefix, "require_prefix_idle"), \
+                    mock.patch.object(
+                        prefix, "repair_managed_prefix_user32") as repair, \
+                    mock.patch.object(prefix, "ok"):
+                self.assertTrue(prefix.boot_prefix(pfx))
+
+            self.assertEqual(
+                (pfx / "drive_c/windows/system32/ntdll.dll").read_bytes(),
+                b"new-ntdll-64")
+            self.assertEqual(prefix.read_managed_engine_rev(pfx),
+                             prefix.WINEGDK_BUILD_REV)
+            repair.assert_called_once_with(pfx)
+
+    def test_boot_prefix_skips_refresh_when_engine_matches(self):
+        with tempfile.TemporaryDirectory() as td:
+            engine, pfx = self._runtime_paths(
+                Path(td), marker_rev=prefix.WINEGDK_BUILD_REV)
+            compat = Path(td) / "compatdata"
+            m = self._managed(engine, pfx)
+            with m[0], m[1], m[2], m[3], \
+                    mock.patch.object(prefix, "COMPAT", compat), \
+                    mock.patch.object(prefix, "require_prefix_idle") as idle, \
+                    mock.patch.object(
+                        prefix, "repair_managed_prefix_user32"), \
+                    mock.patch.object(prefix, "ok"):
+                self.assertTrue(prefix.boot_prefix(pfx))
+
+            idle.assert_not_called()
+            self.assertEqual(
+                (pfx / "drive_c/windows/system32/user32.dll").read_bytes(),
+                b"old-user32-64")
+
+    def test_engine_only_dlls_are_not_injected_into_prefix(self):
+        # A DLL the engine ships but the prefix lacks is deliberately NOT
+        # copied in: a prefix's system dir is the subset wineboot installed
+        # and Wine loads the rest from the engine dir. Only the prefix's
+        # existing DLLs are refreshed (issue #135).
+        with tempfile.TemporaryDirectory() as td:
+            engine, pfx = self._runtime_paths(Path(td))
+            e64 = engine / "files/lib/wine/x86_64-windows"
+            (e64 / "xinput.dll").write_bytes(b"engine-only-xinput")
+            m = self._managed(engine, pfx)
+            with m[0], m[1], m[2], m[3], \
+                    mock.patch.object(prefix, "require_prefix_idle") as idle, \
+                    mock.patch.object(prefix, "ok"):
+                changed = prefix.refresh_managed_prefix_runtime(pfx)
+
+            sys32 = pfx / "drive_c/windows/system32"
+            self.assertTrue(changed)
+            self.assertEqual((sys32 / "user32.dll").read_bytes(),
+                             b"new-user32-64")
+            self.assertEqual((sys32 / "ntdll.dll").read_bytes(),
+                             b"new-ntdll-64")
+            self.assertFalse((sys32 / "xinput.dll").exists())
+            self.assertFalse(
+                (sys32 / "xinput.dll.bol-runtime-backup").exists())
+            idle.assert_called_once_with(
+                pfx, "refresh the managed Wine runtime")
+
+
 class PrefixSetupTests(unittest.TestCase):
     def test_setup_stops_before_gameinput_when_prefix_boot_fails(self):
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
Fixes #135.

## Problem

An engine upgrade (e.g. `wow64-archs-native6` → `wow64-archs-native12`) reused the existing Wine prefix but refreshed only `user32.dll`, leaving every other cached `system32`/`syswow64` DLL from the previous engine. The new pure-WoW64 runtime then ran against a mixed prefix and faulted Minecraft's account/menu path — the repeatable `Unhandled page fault 0x140427AB5` signature from #135.

This is also why the rollback workaround in #135 worked: returning to `native6` paired the prefix with the engine whose DLLs it already cached, rather than `native12` being broken in itself.

## Fix

- Record the engine revision in the managed prefix (`.bol-engine-rev` marker).
- On a missing/mismatched marker, copy the current engine's `x86_64-windows`/`i386-windows` DLLs over the prefix's *existing* system DLLs — atomic stage + SHA-256 verify + per-DLL backup — preserving `drive_c/users` (worlds, settings, login).
- Managed prefix + managed engine only; custom prefixes/engines are never touched.
- Engine-only DLLs are deliberately not injected: a prefix's system dir is the subset `wineboot` installed and Wine loads the rest straight from the engine dir.

## Notes for review

- Rebased onto current `main` (v2.1.2): the engine-refresh hook is adapted to the new `_run_wineboot` retry loop in `boot_prefix` from the #138 fix. The two fixes are orthogonal — #138 recovers a failing fresh prefix creation, this one refreshes stale DLLs in an existing prefix after an engine upgrade.
- The v2.1.2 notes suspect a managed-engine regression between `native6` and `native12`; the evidence here points at the mixed prefix instead. If the engine itself were regressed, the rollback would not have fixed machines whose prefix was created on `native12`, and refreshing the DLLs would not clear the fault.

## Testing

198 new tests in `tests/test_prefix_safety.py` covering: refresh content + marker recording, atomicity/backup behaviour, engine-only DLLs not injected, custom prefix/engine/custom `BOL_WINEPREFIX` never touched, and `boot_prefix` integration. Full suite green.
