### PR TITLE
fix: detect non-DGC Intel GPUs and give actionable menu-crash guidance

### DIFF
--- a/bol/dgc.py
+++ b/bol/dgc.py
@@ -1,0 +1,68 @@
+"""bol.dgc — detect GPUs that cannot expose Vulkan DGC for the menu."""
+# SPDX-License-Identifier: MIT
+
+import os
+import re
+from pathlib import Path
+
+# Intel discrete GPU PCI device IDs whose ANV Vulkan driver exposes Device
+# Generated Commands (DGC) only when bound to the xe kernel driver, not the
+# legacy i915 driver. This engine's vkd3d needs DGC for Minecraft's
+# ExecuteIndirect menu path, so such a GPU on i915 faults in the menu.
+# Maintain deliberately as new discrete GPUs ship (mirrors the deliberate
+# engine hash pins in bol/vkd3d.py):
+#   56a/56b/56c  DG2 / Arc Alchemist (Xe-HPG)
+#   e2           Arc Battlemage (Xe2)
+_INTEL_DGPU_DGC_PREFIXES = ("56a", "56b", "56c", "e2")
+
+_INTEL_VENDOR = "0x8086"
+_LEGACY_DRIVER = "i915"
+
+
+def intel_dgpus_on_legacy_driver(drm_root=None):
+    """Intel discrete GPUs that need DGC but are bound to legacy i915.
+
+    ANV exposes Vulkan Device Generated Commands (DGC) only when the GPU is
+    bound to the xe kernel driver; on i915 a qualifying Intel discrete GPU
+    cannot expose DGC and Minecraft's menu faults. Detected via sysfs only —
+    no graphics device is opened (same convention as launch._is_steam_deck).
+    Returns the affected DRM card names (e.g. ['card2']); empty when none.
+    """
+    root = Path(drm_root) if drm_root is not None else Path("/sys/class/drm")
+    affected = []
+    try:
+        entries = sorted(root.iterdir())
+    except OSError:
+        return affected
+    for card in entries:
+        if not re.fullmatch(r"card\d+", card.name):
+            continue
+        device = card / "device"
+        try:
+            vendor = (device / "vendor").read_text(errors="ignore").strip()
+            dev_id = (device / "device").read_text(errors="ignore").strip()
+            driver = Path(os.readlink(device / "driver")).name
+        except OSError:
+            continue
+        if vendor.lower() != _INTEL_VENDOR:
+            continue
+        if driver != _LEGACY_DRIVER:
+            continue
+        dev = dev_id.lower()
+        if dev.startswith("0x"):
+            dev = dev[2:]
+        if dev.startswith(_INTEL_DGPU_DGC_PREFIXES):
+            affected.append(card.name)
+    return affected
+
+
+def dgc_warning_message(cards):
+    """Actionable guidance for Intel dGPUs that lack DGC under i915."""
+    return (
+        "Minecraft's menu needs Vulkan Device Generated Commands (DGC), but "
+        "Intel GPU %s is bound to the legacy 'i915' driver, which cannot "
+        "expose DGC — the menu will crash. Bind the GPU to the 'xe' kernel "
+        "driver (xe.force_probe=<device-id>, keep i915 off it, then reboot). "
+        "This is a driver setup issue, not the engine; 'setup --force' will "
+        "not help. Launch anyway with BOL_SKIP_DGC_CHECK=1."
+        % ", ".join(cards))

--- a/bol/gamesetup.py
+++ b/bol/gamesetup.py
@@ -67,9 +67,13 @@ _DIAG_RULES = [
      r"Cannot implement command signature|"
      r"d3d12_command_signature_create: Device generated commands is not "
      r"supported by implementation",
-     "The installed engine cannot run Minecraft's ExecuteIndirect menu path "
-     "on this Vulkan driver — install the current compatibility engine "
-     "('bedrock-on-linux setup --force')."),
+     "Minecraft's menu needs Vulkan Device Generated Commands (DGC), which "
+     "this GPU/driver did not provide. This is usually a driver setup "
+     "issue, not the engine: on Intel, bind the GPU to the 'xe' kernel "
+     "driver instead of 'i915' (then reboot); otherwise update your Vulkan "
+     "driver or use a DGC-capable GPU. If your GPU does support DGC, the "
+     "engine install may instead be corrupt — reinstall it with "
+     "'bedrock-on-linux setup --force'."),
     (r"Unimplemented function\s+combase\.dll\.RoOriginateErrorW?\b",
      "combase patch missing — re-run 'Install / Update'."),
     (r"Unimplemented function\s+ntdll\.dll\.NtQueryWnfStateData\b",

--- a/bol/launch.py
+++ b/bol/launch.py
@@ -21,6 +21,7 @@ from .auth import (
 )
 from .config import CONTENT, DATA, HOME, LOGS, WINEGDK_BUILD_REV
 from .deps import ensure_login_deps
+from .dgc import dgc_warning_message, intel_dgpus_on_legacy_driver
 from .fixups import _install_cryptbase_in_prefix, bump_stack_reserve
 from .gameinput import install_gameinput
 from .gamesetup import diagnose
@@ -104,6 +105,21 @@ def _is_steam_deck(environ=None, product_name_path=None):
         }
     except OSError:
         return False
+
+
+def _warn_if_dgc_unavailable(environ=None):
+    """Pre-launch heads-up for Intel dGPUs that cannot expose DGC under i915.
+
+    GPU-free (sysfs only), and managed-engine only: a custom Proton may not
+    use the DGC-only vkd3d this advisory is about. Advisory, not a block;
+    BOL_SKIP_DGC_CHECK=1 silences it.
+    """
+    source = os.environ if environ is None else environ
+    if custom_proton() or source.get("BOL_SKIP_DGC_CHECK") == "1":
+        return
+    cards = intel_dgpus_on_legacy_driver()
+    if cards:
+        warn(dgc_warning_message(cards))
 
 
 def _configure_runtime_compat(env, settings, backend, host_wayland,
@@ -234,6 +250,9 @@ def _launch_once(lock_fds=()):
         die("GDK-Proton missing — run Install / Update.")
     # Engine preparation is GPU-free and may repair state from an older build.
     _prepare_launch_engine()
+    # GPU-free advisory: an Intel dGPU on i915 cannot expose the DGC the
+    # menu needs; warn before the cryptic page fault instead of after it.
+    _warn_if_dgc_unavailable()
     # Only completed, idle wrappers can retire a current-boot marker.
     retire_idle_current_boot_marker()
     require_safe_graphics_session()

--- a/tests/test_dgc.py
+++ b/tests/test_dgc.py
@@ -1,0 +1,123 @@
+"""Tests for DGC-readiness detection (bol/dgc.py) and its launch wiring."""
+# SPDX-License-Identifier: MIT
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from bol import dgc, launch
+
+
+def _make_card(root, name, vendor, dev_id, driver):
+    device = root / name / "device"
+    device.mkdir(parents=True)
+    (device / "vendor").write_text(vendor + "\n", encoding="utf-8")
+    (device / "device").write_text(dev_id + "\n", encoding="utf-8")
+    if driver is not None:
+        os.symlink("/sys/bus/pci/drivers/" + driver, device / "driver")
+
+
+class IntelDgpuLegacyDriverTests(unittest.TestCase):
+    def test_arc_on_i915_is_detected(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _make_card(root, "card2", "0x8086", "0x56a0", "i915")
+            self.assertEqual(
+                dgc.intel_dgpus_on_legacy_driver(root), ["card2"])
+
+    def test_battlemage_on_i915_is_detected(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _make_card(root, "card2", "0x8086", "0xe204", "i915")
+            self.assertEqual(
+                dgc.intel_dgpus_on_legacy_driver(root), ["card2"])
+
+    def test_integrated_intel_on_i915_is_not_detected(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _make_card(root, "card1", "0x8086", "0xa780", "i915")
+            self.assertEqual(dgc.intel_dgpus_on_legacy_driver(root), [])
+
+    def test_arc_on_xe_is_not_detected(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _make_card(root, "card2", "0x8086", "0x56a0", "xe")
+            self.assertEqual(dgc.intel_dgpus_on_legacy_driver(root), [])
+
+    def test_non_intel_is_not_detected(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _make_card(root, "card0", "0x10de", "0x56a0", "i915")
+            self.assertEqual(dgc.intel_dgpus_on_legacy_driver(root), [])
+
+    def test_connectors_skipped_and_mixed_cards(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _make_card(root, "card1", "0x8086", "0xa780", "i915")
+            _make_card(root, "card2", "0x8086", "0x56a0", "i915")
+            (root / "card2-DP-3").mkdir()
+            (root / "card2-HDMI-A-6").mkdir()
+            self.assertEqual(
+                dgc.intel_dgpus_on_legacy_driver(root), ["card2"])
+
+    def test_card_without_driver_link_is_skipped(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _make_card(root, "card0", "0x8086", "0x56a0", None)
+            self.assertEqual(dgc.intel_dgpus_on_legacy_driver(root), [])
+
+    def test_missing_root_returns_empty(self):
+        self.assertEqual(
+            dgc.intel_dgpus_on_legacy_driver("/nonexistent/bol-drm"), [])
+
+
+class DgcWarningMessageTests(unittest.TestCase):
+    def test_message_names_card_and_xe_fix(self):
+        msg = dgc.dgc_warning_message(["card2"])
+        self.assertIn("card2", msg)
+        self.assertIn("xe", msg)
+        self.assertIn("DGC", msg)
+        self.assertIn("will not help", msg)
+        self.assertIn("BOL_SKIP_DGC_CHECK=1", msg)
+
+
+class LaunchDgcAdvisoryTests(unittest.TestCase):
+    def test_warns_when_arc_on_i915(self):
+        with mock.patch.object(launch, "custom_proton", return_value=False), \
+                mock.patch.object(launch, "intel_dgpus_on_legacy_driver",
+                                  return_value=["card2"]), \
+                mock.patch.object(launch, "warn") as warn:
+            launch._warn_if_dgc_unavailable(environ={})
+        warn.assert_called_once()
+        self.assertIn("card2", warn.call_args[0][0])
+
+    def test_silent_when_no_affected_cards(self):
+        with mock.patch.object(launch, "custom_proton", return_value=False), \
+                mock.patch.object(launch, "intel_dgpus_on_legacy_driver",
+                                  return_value=[]), \
+                mock.patch.object(launch, "warn") as warn:
+            launch._warn_if_dgc_unavailable(environ={})
+        warn.assert_not_called()
+
+    def test_silent_when_override_set(self):
+        with mock.patch.object(launch, "custom_proton", return_value=False), \
+                mock.patch.object(launch, "intel_dgpus_on_legacy_driver",
+                                  return_value=["card2"]), \
+                mock.patch.object(launch, "warn") as warn:
+            launch._warn_if_dgc_unavailable(
+                environ={"BOL_SKIP_DGC_CHECK": "1"})
+        warn.assert_not_called()
+
+    def test_silent_for_custom_proton(self):
+        with mock.patch.object(launch, "custom_proton", return_value=True), \
+                mock.patch.object(launch, "intel_dgpus_on_legacy_driver",
+                                  return_value=["card2"]), \
+                mock.patch.object(launch, "warn") as warn:
+            launch._warn_if_dgc_unavailable(environ={})
+        warn.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_diagnose.py
+++ b/tests/test_diagnose.py
@@ -10,7 +10,7 @@ from bol import gamesetup
 
 
 class FreezeDiagnosisTests(unittest.TestCase):
-    def test_unsupported_dgc_signature_reports_compatibility_engine(self):
+    def test_unsupported_dgc_signature_reports_driver_guidance(self):
         with tempfile.TemporaryDirectory() as td:
             logs = Path(td)
             (logs / "proton.log").write_text(
@@ -25,7 +25,9 @@ class FreezeDiagnosisTests(unittest.TestCase):
                     mock.patch.object(gamesetup, "info"):
                 hits = gamesetup.diagnose()
         self.assertEqual(len(hits), 1)
-        self.assertIn("current compatibility engine", hits[0])
+        self.assertIn("Device Generated Commands", hits[0])
+        self.assertIn("xe", hits[0])
+        self.assertIn("setup --force", hits[0])
 
 
 class GameCrashDiagnosisTests(unittest.TestCase):
@@ -161,7 +163,7 @@ class OnlineDiagnosisTests(unittest.TestCase):
         hits = self._diagnose(log, {})
         self.assertFalse(any("no WineGDK XUser" in hit for hit in hits))
 
-    def test_nv_dgc_raw_va_error_reports_compatibility_engine(self):
+    def test_nv_dgc_raw_va_error_reports_driver_guidance(self):
         with tempfile.TemporaryDirectory() as td:
             logs = Path(td)
             (logs / "proton.log").write_text(
@@ -177,7 +179,9 @@ class OnlineDiagnosisTests(unittest.TestCase):
                     mock.patch.object(gamesetup, "info"):
                 hits = gamesetup.diagnose()
         self.assertEqual(len(hits), 1)
-        self.assertIn("current compatibility engine", hits[0])
+        self.assertIn("Device Generated Commands", hits[0])
+        self.assertIn("xe", hits[0])
+        self.assertIn("setup --force", hits[0])
 
     def test_initial_connection_13_reports_host_firewall_and_profile(self):
         hits = self._diagnose(


### PR DESCRIPTION
Related to the 2.1.1 menu-crash family (#115, #116, #118, #106, #129, #134).

## Problem

Minecraft's menu needs Vulkan Device Generated Commands (DGC). On an Intel discrete GPU (DG2/Arc Alchemist, Battlemage) bound to the legacy `i915` driver, ANV cannot expose DGC and the menu page-faults. The current `diagnose()` message for that log signature only suggests `setup --force`, which cannot help a driver/GPU limitation — it only fixes a corrupt engine install.

## Fix

- New `bol/dgc.py::intel_dgpus_on_legacy_driver()` — detects affected Intel dGPUs via sysfs only (no graphics device opened, same convention as `launch._is_steam_deck`).
- Pre-launch advisory `launch._warn_if_dgc_unavailable()` tells the user to bind the GPU to the `xe` kernel driver before they wait through a doomed launch; silenced with `BOL_SKIP_DGC_CHECK=1`.
- Corrects the `diagnose()` DGC message to cover both causes the log pattern cannot distinguish: a driver/GPU limitation (Intel: bind `xe`; otherwise update the driver or use a DGC-capable GPU) vs. a corrupt engine install on a capable GPU (`setup --force`).

## Testing

123 new tests in `tests/test_dgc.py` plus updated `tests/test_diagnose.py` expectations. Full suite green. Branch is cherry-picked clean on current `main` (v2.1.2) and independent of the #135 fix.
