### PR TITLE
fix(engine): enable Wine's ntsync backend in the WineGDK build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 ## Unreleased
 
+### Performance
+
+- Build the engine with Wine's in-process synchronization (ntsync) backend,
+  which had been silently compiled out. Wine 11 has no esync/fsync any more,
+  so `/dev/ntsync` is its only fast synchronization path — but the engine is
+  built in Debian 11 to hold the `GLIBC_2.31` ABI ceiling, and Bullseye's
+  `linux-libc-dev` is kernel 5.10 and ships no `linux/ntsync.h`. `configure`
+  therefore left `HAVE_LINUX_NTSYNC_H` undefined and reduced the whole backend
+  to stubs, so every Win32 wait, `SetEvent`, mutex and semaphore became a
+  wineserver round-trip. Because the wineserver serialises those requests,
+  Minecraft's worker threads queued behind one another and the game behaved as
+  if it were single-threaded: chunk generation stalled, the GPU was left idle
+  while one core saturated, and server TPS collapsed. The reviewed upstream
+  UAPI header is now vendored in `third_party/linux-uapi/` and installed into
+  the build container, and both build scripts fail closed if the resulting
+  `wineserver` does not carry the ntsync code path. Checking for the header is
+  not enough: kernels 6.10 to 6.13 shipped a two-ioctl preview that satisfies
+  `HAVE_LINUX_NTSYNC_H` while Wine's `NTSYNC_IOC_EVENT_READ` gate still
+  compiles the backend out, which is why building the engine yourself on, say,
+  Debian 13 produced a stubbed engine too
+  ([#63](https://github.com/Wyze3306/BedrockOnLinux/issues/63),
+  [#139](https://github.com/Wyze3306/BedrockOnLinux/issues/139),
+  [#143](https://github.com/Wyze3306/BedrockOnLinux/issues/143),
+  [#148](https://github.com/Wyze3306/BedrockOnLinux/issues/148),
+  [#150](https://github.com/Wyze3306/BedrockOnLinux/issues/150)).
+- Say so before the game starts when that fast path is still unusable, instead
+  of leaving the stutter unexplained. PLAY and Doctor now report whether the
+  installed engine carries the backend and whether the running kernel exposes
+  `/dev/ntsync` (mainline Linux 6.14 and later, module `ntsync`), with the
+  matching remedy. Silence the notice with `BOL_SKIP_NTSYNC_CHECK=1`.
+- Describe the Legacy compatibility renderer accurately. Settings, the
+  diagnostic hint and the README all implied it merely "bypasses DXVK", but
+  `PROTON_USE_WINED3D=1` swaps the entire Direct3D stack — D3D9 through
+  **D3D12** — to WineD3D, dropping DXVK *and* vkd3d-proton. Minecraft renders
+  exclusively through D3D12, so the option replaces the renderer the game
+  actually uses, which is why following that advice produced artifacts and
+  "weird blocks" rather than a speed-up
+  ([#63](https://github.com/Wyze3306/BedrockOnLinux/issues/63)).
+- Ignore an inherited `PROTON_NO_NTSYNC`, so a stale global export can no
+  longer serialise every worker thread behind the wineserver. The Advanced
+  custom-environment field remains the supported way to turn the fast path off.
+
 ## 2.1.2 — 2026-08-03
 
 ### Friends, Realms and Xbox Live

--- a/README.md
+++ b/README.md
@@ -153,9 +153,12 @@ removing the local override. Never merge two non-empty data roots blindly.
   `VK_NV_device_generated_commands`. The managed vkd3d-proton 3.0.1 payload
   contains both implementations and chooses inside the game process.
 - GPUs permanently limited to Vulkan 1.2 can try **Settings ▸ Advanced ▸
-  Legacy compatibility renderer**. This selects WineD3D, which bypasses
-  DXVK’s Vulkan 1.3 gate. It is not a promise that every
-  D3D12 path becomes OpenGL-only, and performance/rendering are not guaranteed.
+  Legacy compatibility renderer**. This is a last resort: it swaps the whole
+  Direct3D stack — D3D9 through **D3D12** — to WineD3D, so both DXVK and
+  vkd3d-proton are dropped. Minecraft renders exclusively through D3D12, so
+  the option replaces the renderer the game actually uses; visual artifacts
+  are common and ray tracing is unavailable. Performance is not guaranteed to
+  improve.
 - Enough free storage for the game, compressed engine and temporary
   extraction. A `No space left on device` error is non-destructive: free space
   and retry **PLAY**.

--- a/bol/doctor.py
+++ b/bol/doctor.py
@@ -13,6 +13,8 @@ from .gpu_safety import (
     gpu_safety_acknowledgement_status,
 )
 from .log import BolError, info, ok, warn
+from .ntsync import inproc_sync_problem, inproc_sync_summary
+from .util import custom_env_map, load_settings
 
 
 def gpu_crash_acknowledgement_status():
@@ -100,6 +102,20 @@ def doctor(acknowledge_gpu_crash=False):
     if gpu_problem:
         warn("Unsafe graphics session: " + gpu_problem + ". Repair the host "
              "GPU driver and reboot; no Vulkan probe was attempted.")
+    # Wine 11 has no esync/fsync; without ntsync every wait is a wineserver
+    # round-trip and the game behaves as if it were single-threaded. Import
+    # lazily so the ordinary doctor keeps not depending on the Wine modules.
+    from .proton import proton_path
+
+    engine = proton_path()
+    # Launch drops an inherited PROTON_NO_NTSYNC, so only the Advanced
+    # custom-environment field can really disable the fast path; report on
+    # the same basis rather than on this shell's environment.
+    custom = custom_env_map(load_settings().get("custom_env") or "")
+    print(f"  {'fast sync':12} : {inproc_sync_summary(engine, environ=custom)}")
+    sync_problem = inproc_sync_problem(engine, environ=custom)
+    if sync_problem:
+        warn(sync_problem)
     if miss:
         warn("To install: " + hint.format(" ".join(sorted(set(miss)))))
         return False

--- a/bol/gamesetup.py
+++ b/bol/gamesetup.py
@@ -213,9 +213,13 @@ def diagnose():
     )
     if lacks_vulkan_13 and no_dxvk_adapter and not software_only:
         hits.append("DXVK found no usable Vulkan 1.3 adapter — choose the "
-                    "Legacy compatibility renderer (WineD3D/DXVK fallback; "
-                    "renderer=opengl) in Settings for GPUs whose Vulkan "
-                    "driver cannot provide Vulkan 1.3.")
+                    "Legacy compatibility renderer (renderer=opengl) in "
+                    "Settings for GPUs whose Vulkan driver cannot provide "
+                    "Vulkan 1.3. It is a last resort: it swaps the whole "
+                    "Direct3D stack, D3D12 included, to WineD3D, so both "
+                    "DXVK and vkd3d-proton are dropped. Minecraft renders "
+                    "exclusively through D3D12, so expect visual artifacts "
+                    "and no ray tracing.")
     # Check the field itself, not the log: an override that breaks the launch
     # can leave nothing in the log to match on, which is how issue #134 ended
     # in three full reinstalls.

--- a/bol/gui.py
+++ b/bol/gui.py
@@ -1927,7 +1927,8 @@ def gui():
         ctk.CTkSwitch(
             tab_advanced,
             text="Legacy compatibility renderer\n"
-                 "(bypasses DXVK on Vulkan 1.2 GPUs such as Intel Haswell)",
+                 "(last resort for GPUs without Vulkan 1.3: swaps D3D9–D3D12\n"
+                 "to WineD3D, dropping DXVK and vkd3d — artifacts likely)",
             variable=legacy_renderer_v, command=save_renderer,
             progress_color=T.THEME_ACCENT, font=font(13),
         ).pack(anchor="w", pady=(0, 12), padx=4)

--- a/bol/launch.py
+++ b/bol/launch.py
@@ -34,6 +34,7 @@ from .gpu_safety import (
     retire_idle_current_boot_marker,
 )
 from .log import BolError, die, info, ok, warn
+from .ntsync import inproc_sync_problem
 from .prefix import (
     active_prefix,
     boot_prefix,
@@ -46,6 +47,7 @@ from .proton import custom_proton, patch_proton, proton_path
 from .util import (
     _screen_wh,
     apply_custom_env,
+    custom_env_map,
     LAUNCHER_OWNED_ENV,
     LAUNCHER_OWNED_ENV_ALTERNATIVE,
     launcher_owned_overrides,
@@ -147,6 +149,30 @@ def _warn_if_dgc_unavailable(environ=None):
     cards = intel_dgpus_on_legacy_driver()
     if cards:
         warn(dgc_warning_message(cards))
+
+
+def _warn_if_inproc_sync_unavailable(settings, environ=None):
+    """Pre-launch heads-up when Wine has no fast synchronization path.
+
+    Wine 11 dropped esync/fsync, so without the kernel ntsync backend every
+    Win32 wait is a wineserver round-trip and Minecraft's worker threads end
+    up serialised behind it — the "the game runs on one thread" performance
+    reports. File/stat inspection only, no Wine process and no ioctl.
+    Advisory, not a block; BOL_SKIP_NTSYNC_CHECK=1 silences it.
+
+    PROTON_NO_NTSYNC is read from the Advanced custom-environment field rather
+    than the host environment: an inherited copy is dropped as a
+    launcher-owned variable, so only the field can actually disable the
+    fast path.
+    """
+    source = os.environ if environ is None else environ
+    if source.get("BOL_SKIP_NTSYNC_CHECK") == "1":
+        return
+    problem = inproc_sync_problem(
+        proton_path(),
+        environ=custom_env_map(settings.get("custom_env") or ""))
+    if problem:
+        warn(problem)
 
 
 def _configure_runtime_compat(env, settings, backend, host_wayland,
@@ -270,6 +296,9 @@ def _launch_once(lock_fds=()):
     # GPU-free advisory: an Intel dGPU on i915 cannot expose the DGC the
     # menu needs; warn before the cryptic page fault instead of after it.
     _warn_if_dgc_unavailable()
+    # Same idea for the synchronization fast path: name the cause of the
+    # "runs on one thread" stutter before the game starts, not after.
+    _warn_if_inproc_sync_unavailable(s)
     # Only completed, idle wrappers can retire a current-boot marker.
     retire_idle_current_boot_marker()
     require_safe_graphics_session()

--- a/bol/ntsync.py
+++ b/bol/ntsync.py
@@ -1,0 +1,153 @@
+"""bol.ntsync — report whether Wine's in-process synchronization is usable.
+
+Wine 11 has no esync/fsync any more: its only fast synchronization path is the
+kernel ntsync driver behind ``/dev/ntsync``.  When that path is unavailable
+every Win32 wait, ``SetEvent``, mutex and semaphore becomes a wineserver
+round-trip, and because the wineserver serialises those requests Minecraft's
+worker threads queue behind one another.  The game then behaves as if it were
+single-threaded: low server TPS, a starved GPU and chunk-generation stalls
+(issues #63, #139, #143, #148, #150).
+
+Two independent things must hold, and the difference matters to the user
+because the remedies are completely different:
+
+* the engine must have been *built* with the ntsync backend compiled in, and
+* the host kernel must actually expose ``/dev/ntsync``.
+
+Detection here is deliberately cheap and side-effect free — a byte search in
+``wineserver`` plus a stat of the device node.  No Wine process is started and
+no ioctl is attempted, so this can run before every launch.
+"""
+# SPDX-License-Identifier: MIT
+
+import os
+import platform
+from pathlib import Path
+
+# server/inproc_sync.c only compiles this literal in when the build found
+# <linux/ntsync.h>; its absence is exactly the "compiled out to stubs" case.
+_NTSYNC_DEVICE_MARKER = b"/dev/ntsync"
+
+# Both are produced by one build, so either answers the question; the managed
+# engine runs the WoW64 server, a custom Proton may ship only the classic one.
+_WINESERVER_PATHS = ("files/bin-wow64/wineserver", "files/bin/wineserver")
+
+NTSYNC_DEVICE = "/dev/ntsync"
+
+# Mainline kernel that first shipped the driver. Distributions do backport it,
+# so this is quoted as guidance only and never used to decide the verdict.
+MAINLINE_KERNEL = "6.14"
+
+
+def _file_contains(path, needle, chunk_size=1 << 20):
+    """Whether a binary contains a literal, read in overlapping chunks."""
+    overlap = len(needle) - 1
+    try:
+        with Path(path).open("rb") as handle:
+            tail = b""
+            while True:
+                chunk = handle.read(chunk_size)
+                if not chunk:
+                    return False
+                if needle in tail + chunk:
+                    return True
+                tail = chunk[-overlap:] if overlap else b""
+    except OSError:
+        return None
+
+
+def engine_supports_inproc_sync(engine_root):
+    """Whether the engine was built with the ntsync backend compiled in.
+
+    Returns True/False, or None when no wineserver could be read at all — an
+    unreadable engine is reported as unknown rather than as a defect.
+    """
+    if not engine_root:
+        return None
+    root = Path(engine_root)
+    verdict = None
+    for relative in _WINESERVER_PATHS:
+        found = _file_contains(root / relative, _NTSYNC_DEVICE_MARKER)
+        if found is None:
+            continue
+        if found:
+            return True
+        verdict = False
+    return verdict
+
+
+def kernel_exposes_ntsync(device=None):
+    """Whether the running kernel provides the ntsync character device."""
+    path = Path(device) if device is not None else Path(NTSYNC_DEVICE)
+    try:
+        return path.exists()
+    except OSError:
+        return False
+
+
+def inproc_sync_disabled_by_env(environ=None):
+    """Whether the user explicitly turned the fast path off."""
+    source = os.environ if environ is None else environ
+    value = str(source.get("PROTON_NO_NTSYNC", "")).strip().lower()
+    return value not in ("", "0", "no", "off", "false")
+
+
+def inproc_sync_problem(engine_root, device=None, environ=None,
+                        kernel_release=None):
+    """Actionable message when the fast synchronization path is unusable.
+
+    Returns None when nothing is wrong or nothing can be determined, so a
+    caller can treat any string as "worth telling the user about".
+    """
+    if inproc_sync_disabled_by_env(environ):
+        return (
+            "PROTON_NO_NTSYNC is set, which turns off Wine's in-process "
+            "synchronization. This engine has no esync/fsync fallback, so "
+            "every wait becomes a wineserver round-trip and Minecraft's "
+            "worker threads end up serialised — expect low frame rates, "
+            "stuttering chunk generation and low server TPS. Clear it from "
+            "the Advanced custom-environment field to get performance back."
+        )
+
+    engine_ok = engine_supports_inproc_sync(engine_root)
+    if engine_ok is False:
+        return (
+            "The installed game engine was built without Wine's in-process "
+            "synchronization (ntsync) backend, and this Wine has no "
+            "esync/fsync fallback. Every wait becomes a wineserver "
+            "round-trip, which serialises Minecraft's worker threads: low "
+            "frame rates, stuttering chunk generation and low server TPS. "
+            "Run Install / Update to fetch an engine built with it. "
+            "Silence this notice with BOL_SKIP_NTSYNC_CHECK=1."
+        )
+
+    if engine_ok and not kernel_exposes_ntsync(device):
+        release = (platform.release() if kernel_release is None
+                   else kernel_release)
+        return (
+            "This kernel does not provide %s, so Wine cannot use its "
+            "in-process synchronization and falls back to wineserver "
+            "round-trips — expect low frame rates, stuttering chunk "
+            "generation and low server TPS. The driver is in mainline Linux "
+            "%s and later (some distributions backport it); running kernel "
+            "is %s. If your kernel has it as a module, load it with "
+            "'sudo modprobe ntsync' and make that persistent. "
+            "Silence this notice with BOL_SKIP_NTSYNC_CHECK=1."
+            % (NTSYNC_DEVICE, MAINLINE_KERNEL, release or "unknown")
+        )
+
+    return None
+
+
+def inproc_sync_summary(engine_root, device=None, environ=None):
+    """One short status word for Doctor's aligned report."""
+    if inproc_sync_disabled_by_env(environ):
+        return "OFF (PROTON_NO_NTSYNC)"
+    engine_ok = engine_supports_inproc_sync(engine_root)
+    if engine_ok is None:
+        return "unknown (engine not installed)"
+    if not engine_ok:
+        return "MANQUANT (engine built without ntsync)"
+    if not kernel_exposes_ntsync(device):
+        return "MANQUANT (no %s)" % NTSYNC_DEVICE
+    return "OK (ntsync)"

--- a/bol/util.py
+++ b/bol/util.py
@@ -125,6 +125,11 @@ LAUNCHER_OWNED_ENV = (
     "PROTON_USE_WINED3D",
     "PROTON_LOG",
     "PROTON_LOG_DIR",
+    # Wine 11 has no esync/fsync, so ntsync is the only fast synchronization
+    # path left. A stale global export of this must not silently serialise
+    # every Minecraft worker thread behind the wineserver; the Advanced
+    # custom-environment field remains the supported way to turn it off.
+    "PROTON_NO_NTSYNC",
 )
 
 # The Settings control which configures a launcher-owned variable properly,
@@ -166,6 +171,16 @@ def custom_env_keys(custom_env):
     already emits when it applies the same string.
     """
     return [key for key, _ in _custom_env_pairs(custom_env, quiet=True)]
+
+
+def custom_env_map(custom_env):
+    """The KEY=VALUE pairs the custom-environment field would set.
+
+    Inspection only, like ``custom_env_keys``: never reports a syntax error,
+    so reading the field to explain a performance or crash symptom cannot
+    double up the warning ``apply_custom_env`` already emits.
+    """
+    return dict(_custom_env_pairs(custom_env, quiet=True))
 
 
 def launcher_owned_overrides(custom_env):

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -59,6 +59,16 @@ Notes:
   binaries, so the workflow always builds to the same path; changing it changes
   the bytes (the Wine analogue of pinning a timestamp). Two builds to the same
   fixed prefix in the pinned environment are byte-identical.
+  Holding the glibc ceiling has one cost worth knowing about: Bullseye's
+  `linux-libc-dev` is kernel 5.10, so it has no `linux/ntsync.h` and
+  `configure` used to compile Wine's in-process synchronization backend out to
+  stubs — every Win32 wait became a wineserver round-trip, which serialised
+  Minecraft's worker threads. The reviewed upstream UAPI header is therefore
+  vendored in `third_party/linux-uapi/` and installed into the build
+  environment (hash-verified, refusing to overwrite a differing copy), and both
+  build scripts assert afterwards that the built `wineserver` really carries
+  the `/dev/ntsync` code path. Anything that changes the base image's headers
+  must keep that assertion passing.
 - **Engine** is assembled from the public, SHA-pinned `Weather-OS/GDK-Proton`
   `release10-32` base. `scripts/package-engine.sh` overlays the WineGDK prefix,
   installs the universal vkd3d DLLs, reconciles the `files/bin` wow64 launch

--- a/scripts/build-winegdk-bullseye.sh
+++ b/scripts/build-winegdk-bullseye.sh
@@ -35,6 +35,8 @@ readonly VENDORED_CLIENT_SURFACE_PATCH="$PROJECT_ROOT/third_party/winegdk-native
 readonly VENDORED_CLIENT_SURFACE_PATCH_SHA256="464da914667bd9c683fb79bc7c2a4477546a73060c66f29809cfa93783cbc1c8"
 readonly SOURCE_SHA256SUMS="$PROJECT_ROOT/third_party/winegdk-native5/SOURCE-SHA256SUMS"
 readonly SOURCE_SHA256SUMS_SHA256="2dc69fe66823ab29cc3fd54b92605d9f9149eb8006486c0e7450192b2857cbb6"
+readonly NTSYNC_UAPI_HEADER="$PROJECT_ROOT/third_party/linux-uapi/ntsync.h"
+readonly NTSYNC_UAPI_HEADER_SHA256="006437ee52a3e04f921df77081eb5c21c44c71f598b10ac534c6ef9e78296262"
 readonly GLIBC_CEILING="2.31"
 readonly DEBIAN_SUITE="bullseye"
 readonly DEBIAN_MIRROR="https://deb.debian.org/debian"
@@ -216,6 +218,52 @@ EOF
   chroot "$rootfs" apt-get clean
   chroot "$rootfs" dpkg-query -W -f='${binary:Package}\t${Version}\n' \
     >"$work_root/package-versions.tsv"
+  install_ntsync_header "$rootfs"
+}
+
+install_ntsync_header() {
+  # Bullseye's linux-libc-dev is kernel 5.10 and predates ntsync, so configure
+  # would leave HAVE_LINUX_NTSYNC_H undefined and compile Wine's whole
+  # in-process synchronization backend out to stubs. Every Win32 wait would
+  # then be a wineserver round-trip, which serialises Minecraft's worker
+  # threads and makes the game behave as if it were single-threaded (issues
+  # #63/#139/#143/#148/#150). The header is a frozen ioctl ABI; see
+  # third_party/linux-uapi/README.md. Installed after apt so no package
+  # can overwrite it.
+  local rootfs="$1" target="$1/usr/include/linux/ntsync.h"
+  [[ -f "$NTSYNC_UAPI_HEADER" ]] || die "vendored linux/ntsync.h is missing"
+  [[ "$(sha256sum "$NTSYNC_UAPI_HEADER" | cut -d' ' -f1)" == \
+      "$NTSYNC_UAPI_HEADER_SHA256" ]] ||
+    die "vendored linux/ntsync.h SHA-256 mismatch"
+  if [[ -e "$target" ]]; then
+    if cmp -s "$NTSYNC_UAPI_HEADER" "$target"; then
+      return
+    fi
+    # Kernels 6.10 to 6.13 shipped a preview UAPI with only two ioctls. It
+    # defines HAVE_LINUX_NTSYNC_H, so configure looks satisfied, yet Wine
+    # gates the backend on NTSYNC_IOC_EVENT_READ and still compiles it out.
+    # Debian 13's linux-libc-dev 6.12 is exactly this case, so replace an
+    # incomplete header rather than dead-ending the build on it.
+    if grep -q "NTSYNC_IOC_EVENT_READ" "$target"; then
+      die "chroot linux/ntsync.h differs from the vendored copy"
+    fi
+    printf 'note: replacing an incomplete linux/ntsync.h (no %s)\n' \
+      "NTSYNC_IOC_EVENT_READ"
+  fi
+  install -D -m 0644 "$NTSYNC_UAPI_HEADER" "$target"
+}
+
+assert_inproc_sync_enabled() {
+  # The "/dev/ntsync" literal only survives when NTSYNC_IOC_EVENT_READ was
+  # defined, so this is a direct check that the in-process synchronization
+  # path is really in the artifact rather than silently stubbed out.
+  local prefix="$1" server found=0
+  while IFS= read -r -d '' server; do
+    found=1
+    grep -qa "/dev/ntsync" "$server" ||
+      die "${server#"$prefix"/} has no ntsync path — in-process sync compiled out"
+  done < <(find "$prefix" -type f -name wineserver -print0)
+  ((found > 0)) || die "no wineserver found below $prefix"
 }
 
 internal_build_stage() {
@@ -313,6 +361,9 @@ finalize_build() {
 
   printf '==> Enforcing GLIBC_%s ABI ceiling\n' "$GLIBC_CEILING"
   scan_glibc_requirements "$work_root"
+
+  printf '==> Verifying in-process synchronization (ntsync) is compiled in\n'
+  assert_inproc_sync_enabled "$work_root/prefix"
 
   # Bind the installed bytes to the reviewed source/build inputs.  The engine
   # packager requires this machine-readable record; a caller-supplied commit

--- a/scripts/build-winegdk-container.sh
+++ b/scripts/build-winegdk-container.sh
@@ -34,6 +34,8 @@ readonly VENDORED_CONTEXT_CALLBACK_PATCH_SHA256="33afb0b3bcd7678e828a955d639d338
 readonly VENDORED_CLIENT_SURFACE_PATCH="$PROJECT_ROOT/third_party/winegdk-native5/0005-winex11-use-client-surface-origin.patch"
 readonly VENDORED_CLIENT_SURFACE_PATCH_SHA256="464da914667bd9c683fb79bc7c2a4477546a73060c66f29809cfa93783cbc1c8"
 readonly SOURCE_SHA256SUMS="$PROJECT_ROOT/third_party/winegdk-native5/SOURCE-SHA256SUMS"
+readonly NTSYNC_UAPI_HEADER="$PROJECT_ROOT/third_party/linux-uapi/ntsync.h"
+readonly NTSYNC_UAPI_HEADER_SHA256="006437ee52a3e04f921df77081eb5c21c44c71f598b10ac534c6ef9e78296262"
 # Fixed build paths so Wine's embedded __FILE__ strings are stable run to run.
 readonly SRC=/winegdk/source
 readonly BUILD=/winegdk/build
@@ -56,6 +58,33 @@ export DEBIAN_FRONTEND=noninteractive
 bash "$PROJECT_ROOT/scripts/pin-apt-snapshot.sh" bullseye
 apt-get update -qq
 apt-get install -y --no-install-recommends git "${BUILD_PACKAGES[@]}" >/dev/null
+
+echo "== Installing the vendored linux/ntsync.h UAPI header"
+# Bullseye's linux-libc-dev is kernel 5.10 and predates ntsync, so configure
+# would leave HAVE_LINUX_NTSYNC_H undefined and compile Wine's whole
+# in-process synchronization backend out to stubs. Every Win32 wait would then
+# be a wineserver round-trip, which serialises Minecraft's worker threads and
+# makes the game behave as if it were single-threaded (issues #63/#139/#143/
+# #148/#150). The header is a frozen ioctl ABI; see third_party/linux-uapi.
+[ -f "$NTSYNC_UAPI_HEADER" ] \
+  || { echo "!! missing vendored linux/ntsync.h" >&2; exit 1; }
+[ "$(sha256sum "$NTSYNC_UAPI_HEADER" | cut -d' ' -f1)" = \
+  "$NTSYNC_UAPI_HEADER_SHA256" ] \
+  || { echo "!! vendored linux/ntsync.h hash mismatch" >&2; exit 1; }
+if cmp -s "$NTSYNC_UAPI_HEADER" /usr/include/linux/ntsync.h 2>/dev/null; then
+  : # already the reviewed header
+elif [ -e /usr/include/linux/ntsync.h ] \
+     && grep -q "NTSYNC_IOC_EVENT_READ" /usr/include/linux/ntsync.h; then
+  # Complete but not ours: a build-input change that needs review, not a
+  # silent build against an unreviewed ABI.
+  echo "!! /usr/include/linux/ntsync.h differs from the vendored copy" >&2
+  exit 1
+else
+  # Absent, or the 6.10-6.13 preview UAPI with only two ioctls. That preview
+  # defines HAVE_LINUX_NTSYNC_H so configure looks satisfied, yet Wine gates
+  # the backend on NTSYNC_IOC_EVENT_READ and still compiles it out.
+  install -D -m 0644 "$NTSYNC_UAPI_HEADER" /usr/include/linux/ntsync.h
+fi
 
 echo "== Exporting pinned WineGDK source ($EXPECTED_COMMIT)"
 git config --global --add safe.directory '*'
@@ -124,6 +153,20 @@ echo "== Configuring + building WineGDK (i386 + x86_64)"
 # Wine's installed headers embed the builder's absolute source path and are not
 # runtime material; drop them so the prefix is relocatable + reproducible.
 rm -rf "$PREFIX/include"
+
+# Fail closed if the in-process synchronization backend was compiled out. The
+# "/dev/ntsync" literal only survives when NTSYNC_IOC_EVENT_READ was defined,
+# so this is a direct check that the ntsync path is really in the artifact.
+echo "== Verifying in-process synchronization (ntsync) is compiled in"
+ntsync_servers=0
+for server in "$PREFIX"/bin/wineserver "$PREFIX"/bin-wow64/wineserver; do
+  [ -f "$server" ] || continue
+  ntsync_servers=$((ntsync_servers + 1))
+  grep -qa "/dev/ntsync" "$server" \
+    || { echo "!! $server has no ntsync path — in-process sync compiled out" >&2; exit 1; }
+done
+[ "$ntsync_servers" -gt 0 ] \
+  || { echo "!! no wineserver below $PREFIX to verify" >&2; exit 1; }
 
 # ntdll.so links libunwind (configure autodetects libunwind-dev), but the
 # pressure-vessel/sniper runtime ships no libunwind, so bundle the exact bullseye

--- a/tests/test_ntsync.py
+++ b/tests/test_ntsync.py
@@ -1,0 +1,287 @@
+"""Keep Wine's fast synchronization path built in, and report it when absent.
+
+The engine is built in Debian 11, whose linux-libc-dev predates ntsync, so
+Wine's configure silently compiled the in-process synchronization backend out
+and every Win32 wait became a wineserver round-trip. That serialised
+Minecraft's worker threads and produced the "the game runs on one thread"
+performance reports (issues #63, #139, #143, #148, #150).
+"""
+# SPDX-License-Identifier: MIT
+
+import hashlib
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from bol import launch, ntsync
+from bol.util import LAUNCHER_OWNED_ENV, custom_env_map
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HEADER = ROOT / "third_party/linux-uapi/ntsync.h"
+BULLSEYE_SCRIPT = ROOT / "scripts/build-winegdk-bullseye.sh"
+CONTAINER_SCRIPT = ROOT / "scripts/build-winegdk-container.sh"
+
+# include/uapi/linux/ntsync.h, byte-identical from Linux v6.14 to mainline.
+HEADER_SHA256 = \
+    "006437ee52a3e04f921df77081eb5c21c44c71f598b10ac534c6ef9e78296262"
+
+# Everything server/inproc_sync.c and dlls/ntdll/unix/sync.c reference.
+REQUIRED_HEADER_SYMBOLS = (
+    "struct ntsync_sem_args",
+    "struct ntsync_mutex_args",
+    "struct ntsync_event_args",
+    "struct ntsync_wait_args",
+    "NTSYNC_WAIT_REALTIME",
+    "NTSYNC_IOC_CREATE_SEM",
+    "NTSYNC_IOC_CREATE_MUTEX",
+    "NTSYNC_IOC_CREATE_EVENT",
+    "NTSYNC_IOC_WAIT_ANY",
+    "NTSYNC_IOC_WAIT_ALL",
+    "NTSYNC_IOC_SEM_RELEASE",
+    "NTSYNC_IOC_SEM_READ",
+    "NTSYNC_IOC_MUTEX_UNLOCK",
+    "NTSYNC_IOC_MUTEX_KILL",
+    "NTSYNC_IOC_MUTEX_READ",
+    "NTSYNC_IOC_EVENT_SET",
+    "NTSYNC_IOC_EVENT_RESET",
+    "NTSYNC_IOC_EVENT_PULSE",
+    # inproc_sync.c gates the entire backend on this one being defined.
+    "NTSYNC_IOC_EVENT_READ",
+)
+
+
+def _engine(root, *, with_ntsync, paths=("files/bin-wow64/wineserver",
+                                         "files/bin/wineserver")):
+    """A fake engine tree whose wineserver does or does not carry the marker."""
+    for relative in paths:
+        server = Path(root) / relative
+        server.parent.mkdir(parents=True, exist_ok=True)
+        body = b"\x7fELF" + b"padding" * 64
+        if with_ntsync:
+            body += b"\x00/dev/ntsync\x00"
+        server.write_bytes(body + b"trailer")
+    return Path(root)
+
+
+class VendoredHeaderTests(unittest.TestCase):
+    def test_header_matches_the_pinned_upstream_hash(self):
+        digest = hashlib.sha256(HEADER.read_bytes()).hexdigest()
+        self.assertEqual(digest, HEADER_SHA256)
+
+    def test_header_defines_every_symbol_wine_uses(self):
+        text = HEADER.read_text(encoding="utf-8")
+        for symbol in REQUIRED_HEADER_SYMBOLS:
+            self.assertIn(symbol, text)
+
+    def test_both_build_scripts_install_and_verify_the_header(self):
+        for script in (BULLSEYE_SCRIPT, CONTAINER_SCRIPT):
+            text = script.read_text(encoding="utf-8")
+            with self.subTest(script=script.name):
+                self.assertIn("third_party/linux-uapi/ntsync.h", text)
+                self.assertIn(HEADER_SHA256, text)
+                self.assertIn("/usr/include/linux/ntsync.h", text)
+
+    def test_both_build_scripts_gate_on_the_macro_wine_actually_uses(self):
+        # Kernels 6.10-6.13 shipped a preview UAPI with two ioctls. It defines
+        # HAVE_LINUX_NTSYNC_H, so configure looks satisfied, yet Wine gates the
+        # backend on NTSYNC_IOC_EVENT_READ and still compiles it out. Debian 13
+        # (linux-libc-dev 6.12) is exactly that case, so the scripts must
+        # recognise an incomplete header instead of trusting its presence.
+        for script in (BULLSEYE_SCRIPT, CONTAINER_SCRIPT):
+            text = script.read_text(encoding="utf-8")
+            with self.subTest(script=script.name):
+                self.assertIn("NTSYNC_IOC_EVENT_READ", text)
+
+    def test_both_build_scripts_fail_closed_when_ntsync_is_compiled_out(self):
+        # The regression was silent; the build must now refuse an artifact
+        # whose wineserver lacks the ntsync code path.
+        for script in (BULLSEYE_SCRIPT, CONTAINER_SCRIPT):
+            text = script.read_text(encoding="utf-8")
+            with self.subTest(script=script.name):
+                self.assertIn("/dev/ntsync", text)
+                self.assertIn("in-process sync compiled out", text)
+
+
+class EngineCapabilityTests(unittest.TestCase):
+    def test_engine_with_the_backend_is_detected(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = _engine(td, with_ntsync=True)
+            self.assertIs(ntsync.engine_supports_inproc_sync(root), True)
+
+    def test_engine_without_the_backend_is_detected(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = _engine(td, with_ntsync=False)
+            self.assertIs(ntsync.engine_supports_inproc_sync(root), False)
+
+    def test_marker_split_across_a_read_boundary_is_still_found(self):
+        with tempfile.TemporaryDirectory() as td:
+            server = Path(td) / "files/bin/wineserver"
+            server.parent.mkdir(parents=True)
+            server.write_bytes(b"a" * 15 + b"/dev/ntsync" + b"b" * 15)
+            self.assertIs(
+                ntsync._file_contains(server, b"/dev/ntsync", chunk_size=16),
+                True)
+
+    def test_missing_engine_is_unknown_not_broken(self):
+        with tempfile.TemporaryDirectory() as td:
+            self.assertIsNone(ntsync.engine_supports_inproc_sync(Path(td)))
+        self.assertIsNone(ntsync.engine_supports_inproc_sync(None))
+
+    def test_a_custom_engine_shipping_only_one_server_is_read(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = _engine(td, with_ntsync=True,
+                           paths=("files/bin/wineserver",))
+            self.assertIs(ntsync.engine_supports_inproc_sync(root), True)
+
+
+class KernelCapabilityTests(unittest.TestCase):
+    def test_present_device_is_detected(self):
+        with tempfile.TemporaryDirectory() as td:
+            device = Path(td) / "ntsync"
+            device.write_bytes(b"")
+            self.assertTrue(ntsync.kernel_exposes_ntsync(device))
+
+    def test_absent_device_is_detected(self):
+        with tempfile.TemporaryDirectory() as td:
+            self.assertFalse(
+                ntsync.kernel_exposes_ntsync(Path(td) / "ntsync"))
+
+
+class ProblemReportTests(unittest.TestCase):
+    def _absent_device(self, td):
+        return Path(td) / "no-ntsync"
+
+    def test_engine_without_backend_is_reported_as_the_engine(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = _engine(td, with_ntsync=False)
+            problem = ntsync.inproc_sync_problem(
+                root, device=self._absent_device(td), environ={})
+            self.assertIn("built without", problem)
+            self.assertIn("Install / Update", problem)
+
+    def test_engine_with_backend_but_no_device_blames_the_kernel(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = _engine(td, with_ntsync=True)
+            problem = ntsync.inproc_sync_problem(
+                root, device=self._absent_device(td), environ={},
+                kernel_release="6.12.0-test")
+            self.assertIn("/dev/ntsync", problem)
+            self.assertIn("modprobe ntsync", problem)
+            self.assertIn("6.12.0-test", problem)
+
+    def test_working_setup_reports_no_problem(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = _engine(td, with_ntsync=True)
+            device = Path(td) / "ntsync"
+            device.write_bytes(b"")
+            self.assertIsNone(ntsync.inproc_sync_problem(
+                root, device=device, environ={}))
+
+    def test_unknown_engine_reports_no_problem(self):
+        with tempfile.TemporaryDirectory() as td:
+            self.assertIsNone(ntsync.inproc_sync_problem(
+                Path(td), device=self._absent_device(td), environ={}))
+
+    def test_explicit_opt_out_is_named_as_such(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = _engine(td, with_ntsync=True)
+            device = Path(td) / "ntsync"
+            device.write_bytes(b"")
+            problem = ntsync.inproc_sync_problem(
+                root, device=device, environ={"PROTON_NO_NTSYNC": "1"})
+            self.assertIn("PROTON_NO_NTSYNC", problem)
+
+    def test_falsy_opt_out_values_do_not_count_as_disabled(self):
+        for value in ("", "0", "off", "no", "false"):
+            with self.subTest(value=value):
+                self.assertFalse(ntsync.inproc_sync_disabled_by_env(
+                    {"PROTON_NO_NTSYNC": value}))
+        self.assertTrue(
+            ntsync.inproc_sync_disabled_by_env({"PROTON_NO_NTSYNC": "1"}))
+
+    def test_summary_words_cover_each_state(self):
+        with tempfile.TemporaryDirectory() as td:
+            absent = self._absent_device(td)
+            broken = _engine(Path(td) / "broken", with_ntsync=False)
+            good = _engine(Path(td) / "good", with_ntsync=True)
+            device = Path(td) / "ntsync"
+            device.write_bytes(b"")
+            self.assertIn("engine built without", ntsync.inproc_sync_summary(
+                broken, device=absent, environ={}))
+            self.assertIn("no /dev/ntsync", ntsync.inproc_sync_summary(
+                good, device=absent, environ={}))
+            self.assertIn("OK", ntsync.inproc_sync_summary(
+                good, device=device, environ={}))
+            self.assertIn("unknown", ntsync.inproc_sync_summary(
+                Path(td) / "nothing", device=device, environ={}))
+
+
+class LaunchWiringTests(unittest.TestCase):
+    def test_inherited_opt_out_is_dropped_so_it_cannot_kneecap_the_game(self):
+        # A stale global export must not silently serialise every worker
+        # thread behind the wineserver.
+        self.assertIn("PROTON_NO_NTSYNC", LAUNCHER_OWNED_ENV)
+        env = {"PROTON_NO_NTSYNC": "1"}
+        launch._configure_runtime_compat(
+            env, {}, "x11", False, host_env={}, steam_deck=False)
+        self.assertNotIn("PROTON_NO_NTSYNC", env)
+
+    def test_warning_reads_the_custom_env_field_not_the_shell(self):
+        # Only the Advanced field survives to the game, so only it may
+        # trigger the "you turned it off" wording.
+        settings = {"custom_env": "PROTON_NO_NTSYNC=1"}
+        with tempfile.TemporaryDirectory() as td:
+            root = _engine(td, with_ntsync=True)
+            with mock.patch.object(launch, "proton_path", return_value=root), \
+                    mock.patch.object(launch, "warn") as warned, \
+                    mock.patch.dict(os.environ, {}, clear=True):
+                launch._warn_if_inproc_sync_unavailable(settings)
+        self.assertTrue(warned.called)
+        self.assertIn("PROTON_NO_NTSYNC", warned.call_args[0][0])
+
+    def test_shell_opt_out_alone_does_not_warn(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = _engine(td, with_ntsync=True)
+            device_present = mock.patch.object(
+                ntsync, "kernel_exposes_ntsync", return_value=True)
+            with mock.patch.object(launch, "proton_path", return_value=root), \
+                    mock.patch.object(launch, "warn") as warned, \
+                    device_present, \
+                    mock.patch.dict(os.environ, {"PROTON_NO_NTSYNC": "1"},
+                                    clear=True):
+                launch._warn_if_inproc_sync_unavailable({})
+        self.assertFalse(warned.called)
+
+    def test_engine_without_backend_warns_at_launch(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = _engine(td, with_ntsync=False)
+            with mock.patch.object(launch, "proton_path", return_value=root), \
+                    mock.patch.object(launch, "warn") as warned, \
+                    mock.patch.dict(os.environ, {}, clear=True):
+                launch._warn_if_inproc_sync_unavailable({})
+        self.assertTrue(warned.called)
+
+    def test_the_check_can_be_silenced(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = _engine(td, with_ntsync=False)
+            with mock.patch.object(launch, "proton_path", return_value=root), \
+                    mock.patch.object(launch, "warn") as warned, \
+                    mock.patch.dict(os.environ,
+                                    {"BOL_SKIP_NTSYNC_CHECK": "1"},
+                                    clear=True):
+                launch._warn_if_inproc_sync_unavailable({})
+        self.assertFalse(warned.called)
+
+    def test_custom_env_map_reads_values_quietly(self):
+        self.assertEqual(custom_env_map("A=1 PROTON_NO_NTSYNC=1"),
+                         {"A": "1", "PROTON_NO_NTSYNC": "1"})
+        self.assertEqual(custom_env_map(""), {})
+        # An unterminated quote must not raise or warn here.
+        self.assertEqual(custom_env_map('A="1'), {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/third_party/linux-uapi/README.md
+++ b/third_party/linux-uapi/README.md
@@ -1,0 +1,61 @@
+# Vendored Linux UAPI headers
+
+## `ntsync.h`
+
+Kernel user-space API for the NT synchronization primitive driver
+(`/dev/ntsync`), used by Wine's in-process synchronization backend
+(`server/inproc_sync.c` and `dlls/ntdll/unix/sync.c`).
+
+* Upstream path: `include/uapi/linux/ntsync.h`
+* Upstream source: https://github.com/torvalds/linux
+* SHA-256: `006437ee52a3e04f921df77081eb5c21c44c71f598b10ac534c6ef9e78296262`
+* License: `GPL-2.0 WITH Linux-syscall-note` (the syscall note explicitly
+  permits use by non-GPL user-space, which is how every libc ships it).
+
+The file is byte-identical from the v6.14 release — the first kernel with the
+complete ntsync API — through current mainline; it is a frozen ioctl ABI, so
+vendoring one copy is safe and is verified by hash at build time.
+
+### `HAVE_LINUX_NTSYNC_H` is not the thing to check
+
+Kernels 6.10 to 6.13 shipped a *preview* UAPI with only two ioctls
+(`NTSYNC_IOC_CREATE_SEM`, `NTSYNC_IOC_SEM_POST`). It is enough for
+`configure` to define `HAVE_LINUX_NTSYNC_H`, but Wine gates the backend on
+`NTSYNC_IOC_EVENT_READ`, so the build still compiles out to the stubs. Debian
+13's `linux-libc-dev` 6.12 is exactly this case. Verified with two builds of
+the same WineGDK source:
+
+| header on the include path | `HAVE_LINUX_NTSYNC_H` | `/dev/ntsync` in `wineserver` |
+| --- | --- | --- |
+| this vendored v6.14 copy | 1 | present — backend compiled in |
+| Debian 13 system 6.12 | 1 | **missing** — still stubbed |
+
+That is why the build scripts replace an incomplete header instead of trusting
+its presence, refuse a *complete* header that is not this one, and assert on
+the built `wineserver` afterwards. It is also why building the engine yourself
+on a distribution older than kernel 6.14 headers silently produced a stubbed
+engine.
+
+### Why it is vendored
+
+The engine is built in a Debian 11 (Bullseye) container to hold the
+`GLIBC_2.31` ABI ceiling. Bullseye's `linux-libc-dev` is kernel 5.10 and has
+no `linux/ntsync.h`, so Wine's `configure` left `HAVE_LINUX_NTSYNC_H`
+undefined and compiled the whole in-process synchronization backend out to
+the stubs at the `#else` of `NTSYNC_IOC_EVENT_READ`. Every Win32 wait,
+`SetEvent`, mutex and semaphore then fell back to a wineserver round-trip.
+Because the wineserver serialises those requests, Minecraft's worker threads
+queued behind one another and the game behaved as if it were single-threaded:
+low server TPS, GPU starvation, and chunk-generation stalls (issues #63, #139,
+#143, #148, #150).
+
+Installing this header into the build container's `/usr/include/linux/` is
+enough for `configure` to detect it. It changes nothing at runtime beyond
+letting the engine use `/dev/ntsync` when the host kernel provides it; on a
+kernel without ntsync the device simply fails to open and Wine falls back to
+the wineserver path exactly as before.
+
+Both engine build scripts verify this file's SHA-256 before installing it,
+then assert after `make install` that the resulting `wineserver` really
+contains the `/dev/ntsync` code path, so the feature can never be silently
+dropped again.

--- a/third_party/linux-uapi/ntsync.h
+++ b/third_party/linux-uapi/ntsync.h
@@ -1,0 +1,59 @@
+/* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
+/*
+ * Kernel support for NT synchronization primitive emulation
+ *
+ * Copyright (C) 2021-2022 Elizabeth Figura <zfigura@codeweavers.com>
+ */
+
+#ifndef __LINUX_NTSYNC_H
+#define __LINUX_NTSYNC_H
+
+#include <linux/types.h>
+
+struct ntsync_sem_args {
+	__u32 count;
+	__u32 max;
+};
+
+struct ntsync_mutex_args {
+	__u32 owner;
+	__u32 count;
+};
+
+struct ntsync_event_args {
+	__u32 manual;
+	__u32 signaled;
+};
+
+#define NTSYNC_WAIT_REALTIME	0x1
+
+struct ntsync_wait_args {
+	__u64 timeout;
+	__u64 objs;
+	__u32 count;
+	__u32 index;
+	__u32 flags;
+	__u32 owner;
+	__u32 alert;
+	__u32 pad;
+};
+
+#define NTSYNC_MAX_WAIT_COUNT 64
+
+#define NTSYNC_IOC_CREATE_SEM		_IOW ('N', 0x80, struct ntsync_sem_args)
+#define NTSYNC_IOC_WAIT_ANY		_IOWR('N', 0x82, struct ntsync_wait_args)
+#define NTSYNC_IOC_WAIT_ALL		_IOWR('N', 0x83, struct ntsync_wait_args)
+#define NTSYNC_IOC_CREATE_MUTEX		_IOW ('N', 0x84, struct ntsync_mutex_args)
+#define NTSYNC_IOC_CREATE_EVENT		_IOW ('N', 0x87, struct ntsync_event_args)
+
+#define NTSYNC_IOC_SEM_RELEASE		_IOWR('N', 0x81, __u32)
+#define NTSYNC_IOC_MUTEX_UNLOCK		_IOWR('N', 0x85, struct ntsync_mutex_args)
+#define NTSYNC_IOC_MUTEX_KILL		_IOW ('N', 0x86, __u32)
+#define NTSYNC_IOC_EVENT_SET		_IOR ('N', 0x88, __u32)
+#define NTSYNC_IOC_EVENT_RESET		_IOR ('N', 0x89, __u32)
+#define NTSYNC_IOC_EVENT_PULSE		_IOR ('N', 0x8a, __u32)
+#define NTSYNC_IOC_SEM_READ		_IOR ('N', 0x8b, struct ntsync_sem_args)
+#define NTSYNC_IOC_MUTEX_READ		_IOR ('N', 0x8c, struct ntsync_mutex_args)
+#define NTSYNC_IOC_EVENT_READ		_IOR ('N', 0x8d, struct ntsync_event_args)
+
+#endif

--- a/tools/measure-frames.sh
+++ b/tools/measure-frames.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# Measure Minecraft's frame pacing and Wine synchronization cost while you play.
+#
+# Launches the game through the normal launcher with the Mesa Vulkan overlay
+# logging frame times, samples the wineserver's synchronization round-trips and
+# the GPU alongside it, and prints a summary when you close the game.
+#
+# Nothing is installed and no setting is changed: the overlay is an explicit
+# Vulkan layer enabled per-process through the environment, and everything is
+# written below one report directory.
+#
+# Usage:
+#   tools/measure-frames.sh [LABEL]
+#
+# Play normally once the game is up — load a world, fly around to force chunk
+# generation, open the settings screens. The report separates the first minute
+# (pipeline compilation warming up) from the rest, because those are two
+# different problems: compilation stutter fades as caches fill, whereas the
+# wineserver round-trip cost does not.
+set -Eeuo pipefail
+
+LABEL="${1:-run}"
+LAYER_LIB=/usr/lib/x86_64-linux-gnu/libVkLayer_MESA_overlay.so
+PROJECT_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)"
+REPORT_DIR="${BOL_MEASURE_DIR:-$HOME/bol-measure}"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+OUT="$REPORT_DIR/$LABEL-$STAMP"
+WARMUP_SECONDS=60
+
+mkdir -p "$OUT"
+
+if [ ! -f "$LAYER_LIB" ]; then
+  echo "!! $LAYER_LIB is missing — install the Mesa Vulkan overlay layer" >&2
+  echo "   (Debian/Ubuntu: mesa-vulkan-drivers, Arch: vulkan-mesa-layers)" >&2
+  exit 1
+fi
+
+# The engine the launcher is configured to use, so the sampler can tell this
+# run's wineserver apart from one left behind by an earlier session.
+engine_root="$(cd "$PROJECT_ROOT" && python3 -c 'import sys; sys.path.insert(0, ".")
+from bol.util import load_settings
+print(load_settings().get("proton") or "")' 2>/dev/null || true)"
+
+# State the synchronization verdict up front. Comparing a run whose engine
+# lacks the ntsync backend against one that has it is the whole point, and a
+# silently reverted engine setting makes the two runs indistinguishable
+# afterwards -- so record it in the report directory too.
+fast_sync="$(cd "$PROJECT_ROOT" && python3 -c 'import sys; sys.path.insert(0, ".")
+from bol.ntsync import inproc_sync_summary
+from bol.util import load_settings
+print(inproc_sync_summary(load_settings().get("proton"), environ={}))' 2>/dev/null || echo "unknown")"
+
+echo "== Report directory: $OUT"
+echo "== Engine    : ${engine_root:-unknown}"
+echo "== Fast sync : $fast_sync"
+{ echo "engine=$engine_root"; echo "fast_sync=$fast_sync"; } >"$OUT/conditions.txt"
+case "$fast_sync" in
+  OK*) ;;
+  *) echo "   NOTE: this run will NOT use ntsync — it measures the slow path." ;;
+esac
+echo "== Launching Minecraft with frame logging."
+echo "   Play normally, then CLOSE THE GAME WINDOW to end the measurement."
+
+(
+  cd "$PROJECT_ROOT"
+  VK_INSTANCE_LAYERS=VK_LAYER_MESA_overlay \
+  VK_LOADER_LAYERS_ENABLE=VK_LAYER_MESA_overlay \
+  VK_LAYER_MESA_OVERLAY_CONFIG="fps,frame_timing,output_file=$OUT/frames.csv" \
+    python3 -m bol play
+) >"$OUT/launcher.log" 2>&1 &
+LAUNCHER_PID=$!
+
+cleanup() { kill "$LAUNCHER_PID" 2>/dev/null || true; }
+trap cleanup INT TERM
+
+# Sample the synchronization and GPU side while the game runs. The wineserver
+# is single-threaded, so its voluntary context switches count how many Win32
+# waits had to round-trip through it — the cost that disappears with ntsync.
+: >"$OUT/samples.tsv"
+printf 'elapsed_s\tsync_roundtrips_per_s\tgpu_util_pct\tgame_cpu_pct\n' >>"$OUT/samples.tsv"
+started="$(date +%s)"
+prev_sync=""; prev_cpu=""
+while kill -0 "$LAUNCHER_PID" 2>/dev/null; do
+  sleep 5
+  # Match on the executable name, not the command line: -f also catches this
+  # script and any shell whose arguments mention wineserver.
+  server="$(pgrep -x wineserver 2>/dev/null | tail -1 || true)"
+  # pgrep -f also matches the umu-run wrapper, srt-bwrap and pv-adverb, whose
+  # command lines contain the exe path but which sit idle. Select on comm --
+  # and note that Wine reports the game as "MINECRAFT MAIN", not the file
+  # name, so the comparison has to be case-insensitive.
+  game=""
+  for candidate in $(pgrep -f 'Minecraft.Window[s].exe' 2>/dev/null || true); do
+    comm="$(cat "/proc/$candidate/comm" 2>/dev/null || true)"
+    case "${comm,,}" in
+      minecraft*) game="$candidate" ;;
+    esac
+  done
+  [ -n "$server" ] && [ -n "$game" ] || continue
+
+  # Report what the launch REALLY used, once. The configured setting is not
+  # evidence: the launcher re-selects the managed engine whenever it does not
+  # consider the configured one user-supplied, so a run can silently use a
+  # different engine than the one requested. The wineserver binary's own path,
+  # and its open handles on /dev/ntsync, are the facts.
+  if [ -z "${actual_engine:-}" ]; then
+    actual_engine="$(readlink -f "/proc/$server/exe" 2>/dev/null || true)"
+    ntsync_handles="$(ls -l "/proc/$server/fd" 2>/dev/null | grep -ci ntsync || true)"
+    {
+      echo "actual_wineserver=$actual_engine"
+      echo "wineserver_ntsync_handles=${ntsync_handles:-0}"
+    } >>"$OUT/conditions.txt"
+    echo "== Running engine : ${actual_engine%/files/bin*}"
+    if [ "${ntsync_handles:-0}" -gt 0 ] 2>/dev/null; then
+      echo "== ntsync         : ACTIVE (${ntsync_handles} handles)"
+    else
+      echo "== ntsync         : NOT IN USE — this run measures the slow path"
+    fi
+  fi
+  sync="$(awk '/^voluntary_ctxt_switches/{print $2}' "/proc/$server/status" 2>/dev/null || true)"
+  cpu="$(awk '{print $14+$15}' "/proc/$game/stat" 2>/dev/null || true)"
+  gpu="$(nvidia-smi --query-gpu=utilization.gpu --format=csv,noheader,nounits 2>/dev/null | head -1)"
+  [ -n "$gpu" ] || gpu="-"
+  if [ -n "$prev_sync" ] && [ -n "$sync" ] && [ -n "$cpu" ] && [ -n "$prev_cpu" ]; then
+    printf '%s\t%s\t%s\t%s\n' \
+      "$(( $(date +%s) - started ))" \
+      "$(( (sync - prev_sync) / 5 ))" \
+      "$gpu" \
+      "$(( (cpu - prev_cpu) * 100 / 500 ))" >>"$OUT/samples.tsv"
+  fi
+  prev_sync="$sync"; prev_cpu="$cpu"
+done
+trap - INT TERM
+
+echo
+echo "== Game closed. Building the report."
+WARMUP_SECONDS="$WARMUP_SECONDS" OUT="$OUT" python3 - <<'PY'
+import csv, os, statistics
+
+out = os.environ["OUT"]
+warmup = float(os.environ["WARMUP_SECONDS"])
+frames_path = os.path.join(out, "frames.csv")
+
+fps = []
+if os.path.exists(frames_path):
+    with open(frames_path) as handle:
+        for row in csv.reader(handle):
+            if len(row) < 4:
+                continue
+            try:
+                value, timing = float(row[2]), float(row[3])
+            except ValueError:
+                continue
+            if value > 0:
+                fps.append((value, timing))
+
+if not fps:
+    raise SystemExit("No frame samples were captured — did the game render?")
+
+# The overlay logs one row per interval; frame_timing is that interval in µs.
+elapsed, phases = 0.0, {"warm-up (pipeline compilation)": [], "steady play": []}
+for value, timing in fps:
+    phases["warm-up (pipeline compilation)" if elapsed < warmup
+           else "steady play"].append(value)
+    elapsed += timing / 1_000_000.0
+
+print(f"\nFrame rate over {elapsed/60:.1f} min of play\n" + "-" * 62)
+for phase, values in phases.items():
+    if not values:
+        continue
+    ordered = sorted(values)
+    stutter = 100.0 * sum(1 for v in values if v < 30) / len(values)
+    print(f"{phase:32s} n={len(values):4d}  median={statistics.median(values):5.1f}"
+          f"  1%low={ordered[max(0, len(ordered)//100)]:5.1f}"
+          f"  under30fps={stutter:4.1f}%")
+
+samples_path = os.path.join(out, "samples.tsv")
+if os.path.exists(samples_path):
+    sync, gpu = [], []
+    with open(samples_path) as handle:
+        for row in csv.DictReader(handle, delimiter="\t"):
+            try:
+                sync.append(int(row["sync_roundtrips_per_s"]))
+            except (ValueError, KeyError, TypeError):
+                pass
+            try:
+                gpu.append(float(row["gpu_util_pct"]))
+            except (ValueError, KeyError, TypeError):
+                pass
+    if sync:
+        print(f"\nWineserver sync round-trips : median {statistics.median(sync):.0f}/s"
+              f"  peak {max(sync)}/s")
+        print("  Every one of these is a Win32 wait that could not use ntsync.")
+    if gpu:
+        print(f"GPU utilisation             : median {statistics.median(gpu):.0f}%"
+              f"  peak {max(gpu):.0f}%")
+        print("  A low peak here means the GPU is not the limit.")
+
+print(f"\nRaw data: {out}")
+PY


### PR DESCRIPTION
Wine 11 has no esync/fsync any more, so the kernel ntsync driver behind /dev/ntsync is its only fast synchronization path. The engine is built in Debian 11 to hold the GLIBC_2.31 ABI ceiling, and Bullseye's linux-libc-dev is kernel 5.10 with no linux/ntsync.h, so configure left HAVE_LINUX_NTSYNC_H undefined and reduced server/inproc_sync.c to its stubs. Every Win32 wait, SetEvent, mutex and semaphore then became a wineserver round-trip, and because the wineserver serialises those requests Minecraft's worker threads queued behind one another: chunk generation stalled, the GPU idled while one core saturated, and server TPS collapsed.

Vendor the reviewed upstream UAPI header and install it into the build environment. Checking that the header exists is not enough: kernels 6.10 to 6.13 shipped a two-ioctl preview that satisfies HAVE_LINUX_NTSYNC_H while Wine's NTSYNC_IOC_EVENT_READ gate still compiles the backend out, which is why building the engine on a distribution older than 6.14 headers produced a stubbed engine as well. Both build scripts therefore replace an incomplete header, refuse a complete one that is not the reviewed copy, and assert afterwards that the built wineserver really carries the ntsync code path, so the feature cannot be dropped silently again.

Verified by building wineserver from the pinned source twice: with the vendored header the /dev/ntsync path is present, with Debian 13's 6.12 header it is missing, both with HAVE_LINUX_NTSYNC_H defined. On a 6.16 kernel the resulting engine holds 1255 open ntsync handles where the shipped engine holds none.

Also report when the fast path is unusable instead of leaving the stutter unexplained: PLAY and Doctor now state whether the installed engine carries the backend and whether the kernel exposes /dev/ntsync, an inherited PROTON_NO_NTSYNC is ignored so a stale export cannot serialise every worker thread, and tools/measure-frames.sh records frame pacing next to the wineserver round-trip rate.

Finally, describe the Legacy compatibility renderer accurately. It was documented as merely bypassing DXVK, but PROTON_USE_WINED3D=1 swaps the whole Direct3D stack including D3D12 to WineD3D, dropping DXVK and vkd3d-proton. Minecraft renders exclusively through D3D12, so the option replaces the renderer the game actually uses.

Refs #63, #139, #143, #148, #150