### PR TITLE
Fix `python-xlib` package namefix: use xlib package name

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
         customtkinter
         darkdetect
         packaging
-        python-xlib
+        xlib
         certifi
       ]);
     in


### PR DESCRIPTION
This change fixed the build issue for me on NixOS.

The current `python-xlib` dependency causes evaluation to fail with:

`error: undefined variable 'python-xlib'`

In nixpkgs, the package is available as `python313Packages.xlib` (version 0.33). Changing `python-xlib` to `xlib` fixes the evaluation and allows BedrockOnLinux to build successfully.

I tested this on NixOS with nixpkgs 26.05, and the change resolved the issue.
