### PR TITLE
Restore python-xlib for nixos-unstable

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
         customtkinter
         darkdetect
         packaging
-        xlib
+        python-xlib
         certifi
       ]);
     in


### PR DESCRIPTION
I apologize for the confusion. I found that the issue was caused by a difference between nixos-26.05 and nixos-unstable.

The main BedrockOnLinux flake uses nixos-unstable by default, where `python-xlib` is the correct package name. My configuration uses `inputs.nixpkgs.follows = "nixpkgs"`, which made BedrockOnLinux use nixos-26.05 instead, where the package is exposed as `xlib`.

So the original `python-xlib` is correct for the default upstream configuration, and the problem only occurred because I was using nixos-26.05. The change to `xlib` should therefore be reverted, since it would break the default unstable configuration.

I'll submit a follow-up PR to restore `python-xlib`.
