### PR TITLE
Add profile switcher and profile management to launcher GUI

### DIFF
--- a/bol/gui.py
+++ b/bol/gui.py
@@ -909,12 +909,12 @@ def gui():
             prof_txt_lbl.configure(text_color=T.FG)
 
     def _profile_switch_blocked(parent=root):
-        if ui.get("launch_active") or _mc_running():
+        if ui.get("launch_active"):
             messagebox.showwarning(
                 "Minecraft is running",
                 "Close Minecraft first and wait for the game to exit before switching "
-                "profiles.\n\nTo use multiple profiles simultaneously, open them in a "
-                "new window using the (⧉) button.",
+                "profiles in this window.\n\nTo use multiple profiles simultaneously, "
+                "open them in a new window using the (⧉) button.",
                 parent=parent,
             )
             return True
@@ -937,7 +937,7 @@ def gui():
 
     def _prompt_create_profile():
         close_profile_menu()
-        if ui.get("busy") and not (ui.get("launch_active") or _mc_running()):
+        if ui.get("busy") and not ui.get("launch_active"):
             messagebox.showwarning(
                 "Operation in progress",
                 "Wait for the current preparation task to finish before creating a profile.",
@@ -960,7 +960,7 @@ def gui():
                     write_profile_shortcut(name, profile_dir=profile_dir)
                 except Exception:
                     pass
-            if ui.get("launch_active") or _mc_running():
+            if ui.get("launch_active"):
                 msg = (
                     f"Profile '{name}' was created successfully.\n\n"
                     "Minecraft is currently running in this profile, so the current launcher "
@@ -1042,10 +1042,10 @@ def gui():
                 r_right.pack(side="right", padx=8, pady=6)
 
                 def do_rename(name=p_name, is_act=is_p_active):
-                    if is_act and (ui.get("launch_active") or _mc_running() or ui.get("busy")):
+                    if is_act and (ui.get("launch_active") or ui.get("busy")):
                         messagebox.showwarning(
                             "Rename Profile",
-                            "Cannot rename the active profile while Minecraft or a task is running. Close Minecraft first.",
+                            "Cannot rename the active profile while Minecraft or a task is running in this window. Close Minecraft first.",
                             parent=d,
                         )
                         return

--- a/bol/gui.py
+++ b/bol/gui.py
@@ -780,29 +780,40 @@ def gui():
         def _show(self):
             if self.win is not None:
                 return
-            widget_y = self.widget.winfo_rooty() - root.winfo_rooty()
-            x = self.widget.winfo_rootx() - root.winfo_rootx() + self.widget.winfo_width() // 2
-            
-            if widget_y > root.winfo_height() // 2:
-                y = widget_y - 8
-                anchor = "s"
-            else:
-                y = widget_y + self.widget.winfo_height() + 8
-                anchor = "n"
-            
-            self.win = ctk.CTkFrame(root, fg_color=T.CARD_3, corner_radius=6)
-            lab = ctk.CTkLabel(self.win, text=self.text, fg_color="transparent", text_color=T.FG,
-                               font=font(10))
-            lab.pack(padx=8, pady=4)
-            self.win.place(x=x, y=y, anchor=anchor)
-            self.win.lift()
+            try:
+                if not self.widget.winfo_exists():
+                    return
+                widget_y = self.widget.winfo_rooty() - root.winfo_rooty()
+                x = self.widget.winfo_rootx() - root.winfo_rootx() + self.widget.winfo_width() // 2
+                
+                if widget_y > root.winfo_height() // 2:
+                    y = widget_y - 8
+                    anchor = "s"
+                else:
+                    y = widget_y + self.widget.winfo_height() + 8
+                    anchor = "n"
+                
+                self.win = ctk.CTkFrame(root, fg_color=T.CARD_3, corner_radius=6)
+                lab = ctk.CTkLabel(self.win, text=self.text, fg_color="transparent", text_color=T.FG,
+                                   font=font(10))
+                lab.pack(padx=8, pady=4)
+                self.win.place(x=x, y=y, anchor=anchor)
+                self.win.lift()
+            except Exception:
+                pass
 
         def _hide(self, _e=None):
             if self._job:
-                root.after_cancel(self._job)
+                try:
+                    root.after_cancel(self._job)
+                except Exception:
+                    pass
                 self._job = None
             if self.win is not None:
-                self.win.destroy()
+                try:
+                    self.win.destroy()
+                except Exception:
+                    pass
                 self.win = None
 
     na = NativeAuth()

--- a/bol/gui.py
+++ b/bol/gui.py
@@ -51,8 +51,15 @@ from .prefix import (
 )
 from .profiles import (
     create_profile,
+    current_profile_info,
+    current_profile_name,
+    delete_profile,
+    list_profiles,
     play_launch_command,
     profile_launch_command,
+    profile_shortcuts_supported,
+    relaunch_with_profile,
+    rename_profile,
     require_profile_shortcuts_supported,
     require_shortcuts_supported,
     write_play_shortcut,
@@ -871,6 +878,298 @@ def gui():
     acct_txt_lbl._tooltip = Tooltip(acct_txt_lbl, "")
     acct_btn._tooltip = Tooltip(acct_btn, "")
 
+    cur_prof_info = current_profile_info()
+    cur_prof_name = cur_prof_info["name"]
+    prof_menu_state = {"win": None, "bind_id": None}
+
+    def close_profile_menu():
+        win = prof_menu_state.get("win")
+        if win is not None:
+            try:
+                if prof_menu_state.get("bind_id"):
+                    root.unbind("<Configure>", prof_menu_state["bind_id"])
+            except Exception:
+                pass
+            win.destroy()
+            prof_menu_state["win"] = None
+            prof_menu_state["bind_id"] = None
+            prof_arrow.configure(text="▾", text_color=T.SUB)
+            prof_txt_lbl.configure(text_color=T.FG)
+
+    def _switch_profile_target(profile_path):
+        close_profile_menu()
+        root.destroy()
+        relaunch_with_profile(profile_path)
+
+    def _prompt_create_profile():
+        close_profile_menu()
+        from tkinter import simpledialog
+        name = simpledialog.askstring(
+            "Create account profile",
+            "Profile name (each profile has its own Xbox login, prefix and worlds):",
+            parent=root,
+        )
+        if not name or not name.strip():
+            return
+        name = name.strip()
+        try:
+            profile_dir = create_profile(name)
+            if profile_shortcuts_supported():
+                try:
+                    write_profile_shortcut(name, profile_dir=profile_dir)
+                except Exception:
+                    pass
+            _switch_profile_target(profile_dir)
+        except Exception as exc:
+            messagebox.showerror("Account profile", str(exc), parent=root)
+
+    def _open_profile_manager():
+        close_profile_menu()
+        d = dialog("Manage Profiles", 540, 440)
+
+        ctk.CTkLabel(
+            d, text="Account Profiles", font=font(18, "bold"), text_color=T.FG
+        ).pack(anchor="w", padx=20, pady=(16, 4))
+        ctk.CTkLabel(
+            d,
+            text="Each profile maintains an isolated Xbox sign-in, Wine prefix, worlds, and settings.",
+            font=font(12), text_color=T.SUB, wraplength=500, justify="left"
+        ).pack(anchor="w", padx=20, pady=(0, 12))
+
+        sf = ctk.CTkScrollableFrame(d, fg_color=T.CARD_2, corner_radius=10)
+        sf.pack(fill="both", expand=True, padx=16, pady=(0, 16))
+
+        def refresh_manager():
+            for child in sf.winfo_children():
+                child.destroy()
+
+            profs = list_profiles()
+            active_info = current_profile_info()
+            active_path = active_info.get("path")
+
+            # Default profile row
+            is_def_active = active_path is None
+            def_row = ctk.CTkFrame(sf, fg_color=T.CARD_3 if is_def_active else "transparent", corner_radius=8)
+            def_row.pack(fill="x", padx=4, pady=3)
+
+            def_left = ctk.CTkFrame(def_row, fg_color="transparent")
+            def_left.pack(side="left", padx=8, pady=6)
+            ctk.CTkLabel(def_left, text="Default", font=font(13, "bold"), text_color=T.FG).pack(anchor="w")
+            ctk.CTkLabel(def_left, text="Main installation root", font=font(11), text_color=T.SUB).pack(anchor="w")
+
+            def_right = ctk.CTkFrame(def_row, fg_color="transparent")
+            def_right.pack(side="right", padx=8, pady=6)
+            if is_def_active:
+                ctk.CTkLabel(def_right, text="Active", text_color=T.GREEN, font=font(12, "bold")).pack(side="right", padx=6)
+            else:
+                sw_btn = mkbtn(def_right, "Switch", lambda: (_switch_profile_target(None), d.destroy()), kind="ghost", height=28, width=70)
+                sw_btn.pack(side="right")
+
+            # Custom profile rows
+            for p in profs:
+                p_name = p.get("name", "")
+                p_slug = p.get("slug", "")
+                p_path = p.get("path", "")
+                is_p_active = active_path is not None and Path(active_path).resolve() == Path(p_path).resolve()
+
+                row = ctk.CTkFrame(sf, fg_color=T.CARD_3 if is_p_active else "transparent", corner_radius=8)
+                row.pack(fill="x", padx=4, pady=3)
+
+                r_left = ctk.CTkFrame(row, fg_color="transparent")
+                r_left.pack(side="left", padx=8, pady=6)
+                ctk.CTkLabel(r_left, text=p_name, font=font(13, "bold"), text_color=T.FG).pack(anchor="w")
+                ctk.CTkLabel(r_left, text=f"profiles/{p_slug}", font=font(11), text_color=T.SUB).pack(anchor="w")
+
+                r_right = ctk.CTkFrame(row, fg_color="transparent")
+                r_right.pack(side="right", padx=8, pady=6)
+
+                def do_rename(name=p_name):
+                    from tkinter import simpledialog
+                    new_n = simpledialog.askstring("Rename Profile", f"New name for '{name}':", parent=d)
+                    if not new_n or not new_n.strip() or new_n.strip() == name:
+                        return
+                    try:
+                        rename_profile(name, new_n.strip())
+                        refresh_manager()
+                        prof_var.set(f"Profile: {current_profile_name()}")
+                    except Exception as ex:
+                        messagebox.showerror("Rename Profile", str(ex), parent=d)
+
+                def do_delete(name=p_name, is_act=is_p_active):
+                    if is_act:
+                        messagebox.showwarning(
+                            "Delete Profile",
+                            "Cannot delete the currently active profile. Switch to another profile first.",
+                            parent=d,
+                        )
+                        return
+                    del_msg = f"Are you sure you want to delete profile \x27{name}\x27?\n\nThis will permanently remove its worlds, settings, and player data."
+                    del_msg = (f"Are you sure you want to delete profile \x27{name}\x27?\n\n" + "This will permanently remove its worlds, settings, and player data.")
+                    if not messagebox.askyesno("Delete Profile", del_msg, parent=d):
+                        return
+                    try:
+                        delete_profile(name)
+                        refresh_manager()
+                    except Exception as ex:
+                        messagebox.showerror("Delete Profile", str(ex), parent=d)
+
+                def do_open_folder(path=p_path):
+                    subprocess.Popen(
+                        ["xdg-open", str(path)],
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                    )
+
+                del_btn = mkbtn(r_right, "Delete", lambda n=p_name, a=is_p_active: do_delete(n, a), kind="danger" if not is_p_active else "ghost", height=28, width=64)
+                del_btn.pack(side="right", padx=(4, 0))
+
+                ren_btn = mkbtn(r_right, "Rename", lambda n=p_name: do_rename(n), kind="ghost", height=28, width=64)
+                ren_btn.pack(side="right", padx=(4, 0))
+
+                folder_btn = mkbtn(r_right, "Folder", lambda p=p_path: do_open_folder(p), kind="ghost", height=28, width=60)
+                folder_btn.pack(side="right", padx=(4, 0))
+
+                if is_p_active:
+                    ctk.CTkLabel(r_right, text="Active", text_color=T.GREEN, font=font(12, "bold")).pack(side="right", padx=(0, 6))
+                else:
+                    sw_btn = mkbtn(r_right, "Switch", lambda p=p_path: (_switch_profile_target(p), d.destroy()), kind="ghost", height=28, width=64)
+                    sw_btn.pack(side="right", padx=(0, 6))
+
+        refresh_manager()
+
+    def open_profile_menu():
+        if prof_menu_state["win"] is not None:
+            close_profile_menu()
+            return
+
+        profiles = list_profiles()
+        x = (prof_card.winfo_rootx() - root.winfo_rootx()) / _ui_scale
+        y = (prof_card.winfo_rooty() - root.winfo_rooty() + prof_card.winfo_height()) / _ui_scale
+        w = max(210, prof_card.winfo_width() / _ui_scale)
+
+        total_items = 1 + len(profiles) + 2
+        h = min(300, 20 + 34 * total_items + 14)
+
+        win = ctk.CTkFrame(
+            root, width=w, height=h, fg_color=T.CARD_2, bg_color=T.CARD,
+            border_width=1, border_color=T.BORDER, corner_radius=12,
+        )
+        prof_menu_state["win"] = win
+        win.pack_propagate(False)
+        win.place(x=x, y=y + 4)
+        win.lift()
+
+        prof_arrow.configure(text="▴", text_color=T.THEME_ACCENT)
+        prof_txt_lbl.configure(text_color=T.THEME_ACCENT)
+
+        def update_prof_menu_pos(_event=None):
+            if prof_menu_state["win"] != win:
+                return
+            try:
+                cur_x = (prof_card.winfo_rootx() - root.winfo_rootx()) / _ui_scale
+                cur_y = (prof_card.winfo_rooty() - root.winfo_rooty() + prof_card.winfo_height()) / _ui_scale
+                win.place(x=cur_x, y=cur_y + 4)
+            except Exception:
+                pass
+
+        prof_menu_state["bind_id"] = root.bind("<Configure>", update_prof_menu_pos, add="+")
+
+        sf = ctk.CTkScrollableFrame(win, fg_color="transparent", corner_radius=8)
+        sf.pack(fill="both", expand=True, padx=4, pady=4)
+
+        is_default = cur_prof_info["path"] is None
+        def_btn = ctk.CTkButton(
+            sf,
+            text="Default",
+            anchor="w",
+            height=30,
+            corner_radius=6,
+            font=font(12, "bold" if is_default else "normal"),
+            fg_color=T.THEME_DIM if is_default else "transparent",
+            hover_color=T.THEME_DIM if is_default else T.CARD_3,
+            text_color=T.THEME_ACCENT if is_default else T.FG,
+            command=lambda: _switch_profile_target(None),
+        )
+        def_btn.pack(fill="x", pady=(2, 2))
+
+        for p in profiles:
+            p_name = p.get("name", "")
+            p_path = p.get("path")
+            is_active = (cur_prof_info["path"] is not None
+                         and Path(cur_prof_info["path"]).resolve() == Path(p_path).resolve())
+            btn = ctk.CTkButton(
+                sf,
+                text=p_name,
+                anchor="w",
+                height=30,
+                corner_radius=6,
+                font=font(12, "bold" if is_active else "normal"),
+                fg_color=T.THEME_DIM if is_active else "transparent",
+                hover_color=T.THEME_DIM if is_active else T.CARD_3,
+                text_color=T.THEME_ACCENT if is_active else T.FG,
+                command=lambda path=p_path: _switch_profile_target(path),
+            )
+            btn.pack(fill="x", pady=2)
+
+        divider = ctk.CTkFrame(sf, height=1, fg_color=T.BORDER)
+        divider.pack(fill="x", padx=4, pady=(4, 4))
+
+        new_btn = ctk.CTkButton(
+            sf,
+            text="+ New Profile…",
+            anchor="w",
+            height=30,
+            corner_radius=6,
+            font=font(12, "bold"),
+            fg_color="transparent",
+            hover_color=T.THEME_DIM,
+            text_color=T.THEME_ACCENT,
+            command=_prompt_create_profile,
+        )
+        new_btn.pack(fill="x", pady=(2, 2))
+
+        manage_btn = ctk.CTkButton(
+            sf,
+            text="Manage Profiles…",
+            anchor="w",
+            height=30,
+            corner_radius=6,
+            font=font(12),
+            fg_color="transparent",
+            hover_color=T.CARD_3,
+            text_color=T.SUB,
+            command=_open_profile_manager,
+        )
+        manage_btn.pack(fill="x", pady=(2, 2))
+
+        _enable_scrollable_frame_wheel(sf, win)
+        win.bind("<Escape>", lambda _event: close_profile_menu())
+
+    prof_card = ctk.CTkFrame(top, fg_color=T.CARD, corner_radius=14, cursor="hand2")
+    prof_card.pack(side="right", padx=(0, 10))
+
+    prof_var = tk.StringVar(value=f"Profile: {cur_prof_name}")
+    prof_txt_lbl = ctk.CTkLabel(
+        prof_card, textvariable=prof_var, text_color=T.FG, font=font(13)
+    )
+    prof_txt_lbl.pack(side="left", padx=(14, 4), pady=8)
+
+    prof_arrow = ctk.CTkLabel(
+        prof_card, text="▾", text_color=T.SUB, font=font(14, "bold"), width=12
+    )
+    prof_arrow.pack(side="left", padx=(0, 12), pady=8)
+
+    def _prof_hover(on):
+        active = on or prof_menu_state["win"] is not None
+        prof_txt_lbl.configure(text_color=T.THEME_ACCENT if active else T.FG)
+        prof_arrow.configure(text_color=T.THEME_ACCENT if active else T.SUB)
+
+    for _pw in (prof_card, prof_txt_lbl, prof_arrow):
+        _pw.bind("<Button-1>", lambda _e: open_profile_menu())
+        _pw.bind("<Enter>", lambda _e: _prof_hover(True))
+        _pw.bind("<Leave>", lambda _e: _prof_hover(False))
+        Tooltip(_pw, f"Current profile: {cur_prof_name} (click to switch)")
+
     view_area = ctk.CTkFrame(root, fg_color="transparent")
     view_area.pack(fill="both", expand=True, padx=22, pady=6)
 
@@ -1214,22 +1513,38 @@ def gui():
         
     def global_click(event):
         w = _pick.get("win")
-        if w is None:
-            return
-        try:
-            wx, wy = w.winfo_rootx(), w.winfo_rooty()
-            ww, wh = w.winfo_width(), w.winfo_height()
-            vx, vy = ver_field.winfo_rootx(), ver_field.winfo_rooty()
-            vw, vh = ver_field.winfo_width(), ver_field.winfo_height()
-            mx, my = event.x_root, event.y_root
-            
-            in_w = (wx <= mx <= wx + ww) and (wy <= my <= wy + wh)
-            in_v = (vx <= mx <= vx + vw) and (vy <= my <= vy + vh)
-            
-            if not in_w and not in_v:
-                close_picker()
-        except Exception:
-            pass
+        if w is not None:
+            try:
+                wx, wy = w.winfo_rootx(), w.winfo_rooty()
+                ww, wh = w.winfo_width(), w.winfo_height()
+                vx, vy = ver_field.winfo_rootx(), ver_field.winfo_rooty()
+                vw, vh = ver_field.winfo_width(), ver_field.winfo_height()
+                mx, my = event.x_root, event.y_root
+                
+                in_w = (wx <= mx <= wx + ww) and (wy <= my <= wy + wh)
+                in_v = (vx <= mx <= vx + vw) and (vy <= my <= vy + vh)
+                
+                if not in_w and not in_v:
+                    close_picker()
+            except Exception:
+                pass
+
+        pw = prof_menu_state.get("win")
+        if pw is not None:
+            try:
+                px, py = pw.winfo_rootx(), pw.winfo_rooty()
+                pww, pwh = pw.winfo_width(), pw.winfo_height()
+                cx, cy = prof_card.winfo_rootx(), prof_card.winfo_rooty()
+                cw, ch = prof_card.winfo_width(), prof_card.winfo_height()
+                mx, my = event.x_root, event.y_root
+
+                in_pw = (px <= mx <= px + pww) and (py <= my <= py + pwh)
+                in_pc = (cx <= mx <= cx + cw) and (cy <= my <= cy + ch)
+
+                if not in_pw and not in_pc:
+                    close_profile_menu()
+            except Exception:
+                pass
 
     root.bind_all("<Button-1>", global_click, add="+")
 

--- a/bol/gui.py
+++ b/bol/gui.py
@@ -1054,11 +1054,16 @@ def gui():
                     if not new_n or not new_n.strip() or new_n.strip() == name:
                         return
                     try:
-                        rename_profile(name, new_n.strip())
+                        new_dir = rename_profile(name, new_n.strip())
+                        if is_act and active_path is not None and Path(new_dir).resolve() != Path(active_path).resolve():
+                            _switch_profile_target(new_dir)
+                            d.destroy()
+                            return
                         refresh_manager()
                         prof_var.set(f"Profile: {current_profile_name()}")
                     except Exception as ex:
                         messagebox.showerror("Rename Profile", str(ex), parent=d)
+
 
                 def do_delete(name=p_name, is_act=is_p_active):
                     if is_act:

--- a/bol/gui.py
+++ b/bol/gui.py
@@ -908,13 +908,42 @@ def gui():
             prof_arrow.configure(text="▾", text_color=T.SUB)
             prof_txt_lbl.configure(text_color=T.FG)
 
-    def _switch_profile_target(profile_path):
+    def _profile_switch_blocked(parent=root):
+        if ui.get("launch_active") or _mc_running():
+            messagebox.showwarning(
+                "Minecraft is running",
+                "Close Minecraft first and wait for the game to exit before switching "
+                "profiles.\n\nTo use multiple profiles simultaneously, open them in a "
+                "new window using the (⧉) button.",
+                parent=parent,
+            )
+            return True
+        if ui.get("busy"):
+            messagebox.showwarning(
+                "Operation in progress",
+                "Wait for the current preparation task to finish before switching profiles.",
+                parent=parent,
+            )
+            return True
+        return False
+
+    def _switch_profile_target(profile_path, parent=root):
         close_profile_menu()
+        if _profile_switch_blocked(parent=parent):
+            return False
         root.destroy()
         relaunch_with_profile(profile_path)
+        return True
 
     def _prompt_create_profile():
         close_profile_menu()
+        if ui.get("busy") and not (ui.get("launch_active") or _mc_running()):
+            messagebox.showwarning(
+                "Operation in progress",
+                "Wait for the current preparation task to finish before creating a profile.",
+                parent=root,
+            )
+            return
         from tkinter import simpledialog
         name = simpledialog.askstring(
             "Create account profile",
@@ -931,7 +960,17 @@ def gui():
                     write_profile_shortcut(name, profile_dir=profile_dir)
                 except Exception:
                     pass
-            _switch_profile_target(profile_dir)
+            if ui.get("launch_active") or _mc_running():
+                msg = (
+                    f"Profile '{name}' was created successfully.\n\n"
+                    "Minecraft is currently running in this profile, so the current launcher "
+                    "window cannot be switched.\n\n"
+                    "Would you like to open the new profile in a new window now?"
+                )
+                if messagebox.askyesno("Profile Created", msg, parent=root):
+                    open_profile_window(profile_dir)
+            else:
+                _switch_profile_target(profile_dir)
         except Exception as exc:
             messagebox.showerror("Account profile", str(exc), parent=root)
 
@@ -978,7 +1017,10 @@ def gui():
             if is_def_active:
                 ctk.CTkLabel(def_right, text="Active", text_color=T.GREEN, font=font(12, "bold")).pack(side="right", padx=6)
             else:
-                sw_btn = mkbtn(def_right, "Switch", lambda: (_switch_profile_target(None), d.destroy()), kind="ghost", height=28, width=64)
+                def do_switch_def():
+                    if _switch_profile_target(None, parent=d):
+                        d.destroy()
+                sw_btn = mkbtn(def_right, "Switch", do_switch_def, kind="ghost", height=28, width=64)
                 sw_btn.pack(side="right", padx=(4, 0))
 
             # Custom profile rows
@@ -999,7 +1041,14 @@ def gui():
                 r_right = ctk.CTkFrame(row, fg_color="transparent")
                 r_right.pack(side="right", padx=8, pady=6)
 
-                def do_rename(name=p_name):
+                def do_rename(name=p_name, is_act=is_p_active):
+                    if is_act and (ui.get("launch_active") or _mc_running() or ui.get("busy")):
+                        messagebox.showwarning(
+                            "Rename Profile",
+                            "Cannot rename the active profile while Minecraft or a task is running. Close Minecraft first.",
+                            parent=d,
+                        )
+                        return
                     from tkinter import simpledialog
                     new_n = simpledialog.askstring("Rename Profile", f"New name for '{name}':", parent=d)
                     if not new_n or not new_n.strip() or new_n.strip() == name:
@@ -1039,7 +1088,7 @@ def gui():
                 del_btn = mkbtn(r_right, "Delete", lambda n=p_name, a=is_p_active: do_delete(n, a), kind="danger" if not is_p_active else "ghost", height=28, width=60)
                 del_btn.pack(side="right", padx=(4, 0))
 
-                ren_btn = mkbtn(r_right, "Rename", lambda n=p_name: do_rename(n), kind="ghost", height=28, width=60)
+                ren_btn = mkbtn(r_right, "Rename", lambda n=p_name, a=is_p_active: do_rename(n, a), kind="ghost", height=28, width=60)
                 ren_btn.pack(side="right", padx=(4, 0))
 
                 folder_btn = mkbtn(r_right, "Folder", lambda p=p_path: do_open_folder(p), kind="ghost", height=28, width=54)
@@ -1051,7 +1100,10 @@ def gui():
                 if is_p_active:
                     ctk.CTkLabel(r_right, text="Active", text_color=T.GREEN, font=font(12, "bold")).pack(side="right", padx=(0, 6))
                 else:
-                    sw_btn = mkbtn(r_right, "Switch", lambda p=p_path: (_switch_profile_target(p), d.destroy()), kind="ghost", height=28, width=60)
+                    def do_switch_custom(path=p_path):
+                        if _switch_profile_target(path, parent=d):
+                            d.destroy()
+                    sw_btn = mkbtn(r_right, "Switch", lambda p=p_path: do_switch_custom(p), kind="ghost", height=28, width=60)
                     sw_btn.pack(side="right", padx=(0, 6))
 
         refresh_manager()

--- a/bol/gui.py
+++ b/bol/gui.py
@@ -59,6 +59,7 @@ from .profiles import (
     profile_launch_command,
     profile_shortcuts_supported,
     relaunch_with_profile,
+    open_profile_window,
     rename_profile,
     require_profile_shortcuts_supported,
     require_shortcuts_supported,
@@ -925,7 +926,7 @@ def gui():
 
     def _open_profile_manager():
         close_profile_menu()
-        d = dialog("Manage Profiles", 540, 440)
+        d = dialog("Manage Profiles", 620, 440)
 
         ctk.CTkLabel(
             d, text="Account Profiles", font=font(18, "bold"), text_color=T.FG
@@ -933,7 +934,7 @@ def gui():
         ctk.CTkLabel(
             d,
             text="Each profile maintains an isolated Xbox sign-in, Wine prefix, worlds, and settings.",
-            font=font(12), text_color=T.SUB, wraplength=500, justify="left"
+            font=font(12), text_color=T.SUB, wraplength=580, justify="left"
         ).pack(anchor="w", padx=20, pady=(0, 12))
 
         sf = ctk.CTkScrollableFrame(d, fg_color=T.CARD_2, corner_radius=10)
@@ -959,11 +960,15 @@ def gui():
 
             def_right = ctk.CTkFrame(def_row, fg_color="transparent")
             def_right.pack(side="right", padx=8, pady=6)
+
+            win_btn = mkbtn(def_right, "New Window", lambda: open_profile_window(None), kind="ghost", height=28, width=90)
+            win_btn.pack(side="right", padx=(4, 0))
+
             if is_def_active:
                 ctk.CTkLabel(def_right, text="Active", text_color=T.GREEN, font=font(12, "bold")).pack(side="right", padx=6)
             else:
-                sw_btn = mkbtn(def_right, "Switch", lambda: (_switch_profile_target(None), d.destroy()), kind="ghost", height=28, width=70)
-                sw_btn.pack(side="right")
+                sw_btn = mkbtn(def_right, "Switch", lambda: (_switch_profile_target(None), d.destroy()), kind="ghost", height=28, width=64)
+                sw_btn.pack(side="right", padx=(4, 0))
 
             # Custom profile rows
             for p in profs:
@@ -1003,8 +1008,8 @@ def gui():
                             parent=d,
                         )
                         return
-                    del_msg = f"Are you sure you want to delete profile \x27{name}\x27?\n\nThis will permanently remove its worlds, settings, and player data."
-                    del_msg = (f"Are you sure you want to delete profile \x27{name}\x27?\n\n" + "This will permanently remove its worlds, settings, and player data.")
+                    del_msg = (f"Are you sure you want to delete profile '{name}'?\n\n" +
+                               "This will permanently remove its worlds, settings, and player data.")
                     if not messagebox.askyesno("Delete Profile", del_msg, parent=d):
                         return
                     try:
@@ -1020,19 +1025,22 @@ def gui():
                         stderr=subprocess.DEVNULL,
                     )
 
-                del_btn = mkbtn(r_right, "Delete", lambda n=p_name, a=is_p_active: do_delete(n, a), kind="danger" if not is_p_active else "ghost", height=28, width=64)
+                del_btn = mkbtn(r_right, "Delete", lambda n=p_name, a=is_p_active: do_delete(n, a), kind="danger" if not is_p_active else "ghost", height=28, width=60)
                 del_btn.pack(side="right", padx=(4, 0))
 
-                ren_btn = mkbtn(r_right, "Rename", lambda n=p_name: do_rename(n), kind="ghost", height=28, width=64)
+                ren_btn = mkbtn(r_right, "Rename", lambda n=p_name: do_rename(n), kind="ghost", height=28, width=60)
                 ren_btn.pack(side="right", padx=(4, 0))
 
-                folder_btn = mkbtn(r_right, "Folder", lambda p=p_path: do_open_folder(p), kind="ghost", height=28, width=60)
+                folder_btn = mkbtn(r_right, "Folder", lambda p=p_path: do_open_folder(p), kind="ghost", height=28, width=54)
                 folder_btn.pack(side="right", padx=(4, 0))
+
+                win_btn = mkbtn(r_right, "New Window", lambda p=p_path: open_profile_window(p), kind="ghost", height=28, width=90)
+                win_btn.pack(side="right", padx=(4, 0))
 
                 if is_p_active:
                     ctk.CTkLabel(r_right, text="Active", text_color=T.GREEN, font=font(12, "bold")).pack(side="right", padx=(0, 6))
                 else:
-                    sw_btn = mkbtn(r_right, "Switch", lambda p=p_path: (_switch_profile_target(p), d.destroy()), kind="ghost", height=28, width=64)
+                    sw_btn = mkbtn(r_right, "Switch", lambda p=p_path: (_switch_profile_target(p), d.destroy()), kind="ghost", height=28, width=60)
                     sw_btn.pack(side="right", padx=(0, 6))
 
         refresh_manager()
@@ -1045,10 +1053,10 @@ def gui():
         profiles = list_profiles()
         x = (prof_card.winfo_rootx() - root.winfo_rootx()) / _ui_scale
         y = (prof_card.winfo_rooty() - root.winfo_rooty() + prof_card.winfo_height()) / _ui_scale
-        w = max(210, prof_card.winfo_width() / _ui_scale)
+        w = max(230, prof_card.winfo_width() / _ui_scale)
 
         total_items = 1 + len(profiles) + 2
-        h = min(300, 20 + 34 * total_items + 14)
+        h = min(320, 20 + 36 * total_items + 14)
 
         win = ctk.CTkFrame(
             root, width=w, height=h, fg_color=T.CARD_2, bg_color=T.CARD,
@@ -1077,29 +1085,13 @@ def gui():
         sf = ctk.CTkScrollableFrame(win, fg_color="transparent", corner_radius=8)
         sf.pack(fill="both", expand=True, padx=4, pady=4)
 
-        is_default = cur_prof_info["path"] is None
-        def_btn = ctk.CTkButton(
-            sf,
-            text="Default",
-            anchor="w",
-            height=30,
-            corner_radius=6,
-            font=font(12, "bold" if is_default else "normal"),
-            fg_color=T.THEME_DIM if is_default else "transparent",
-            hover_color=T.THEME_DIM if is_default else T.CARD_3,
-            text_color=T.THEME_ACCENT if is_default else T.FG,
-            command=lambda: _switch_profile_target(None),
-        )
-        def_btn.pack(fill="x", pady=(2, 2))
+        def _add_menu_row(name, path, is_active):
+            row = ctk.CTkFrame(sf, fg_color="transparent")
+            row.pack(fill="x", pady=1)
 
-        for p in profiles:
-            p_name = p.get("name", "")
-            p_path = p.get("path")
-            is_active = (cur_prof_info["path"] is not None
-                         and Path(cur_prof_info["path"]).resolve() == Path(p_path).resolve())
             btn = ctk.CTkButton(
-                sf,
-                text=p_name,
+                row,
+                text=name,
                 anchor="w",
                 height=30,
                 corner_radius=6,
@@ -1107,9 +1099,34 @@ def gui():
                 fg_color=T.THEME_DIM if is_active else "transparent",
                 hover_color=T.THEME_DIM if is_active else T.CARD_3,
                 text_color=T.THEME_ACCENT if is_active else T.FG,
-                command=lambda path=p_path: _switch_profile_target(path),
+                command=lambda: _switch_profile_target(path),
             )
-            btn.pack(fill="x", pady=2)
+            btn.pack(side="left", fill="x", expand=True, padx=(0, 2))
+
+            win_btn = ctk.CTkButton(
+                row,
+                text="⧉",
+                width=28,
+                height=30,
+                corner_radius=6,
+                font=font(12),
+                fg_color="transparent",
+                hover_color=T.CARD_3,
+                text_color=T.SUB,
+                command=lambda: (open_profile_window(path), close_profile_menu()),
+            )
+            win_btn.pack(side="right")
+            Tooltip(win_btn, f"Open {name} in a new window")
+
+        is_default = cur_prof_info["path"] is None
+        _add_menu_row("Default", None, is_default)
+
+        for p in profiles:
+            p_name = p.get("name", "")
+            p_path = p.get("path")
+            is_active = (cur_prof_info["path"] is not None
+                         and Path(cur_prof_info["path"]).resolve() == Path(p_path).resolve())
+            _add_menu_row(p_name, p_path, is_active)
 
         divider = ctk.CTkFrame(sf, height=1, fg_color=T.BORDER)
         divider.pack(fill="x", padx=4, pady=(4, 4))

--- a/bol/profiles.py
+++ b/bol/profiles.py
@@ -76,10 +76,70 @@ def _ensure_shared_link(profile_dir, base_data, name):
     link.symlink_to(target, target_is_directory=True)
 
 
+def _environ_uses_profile_home(environ, profile_dir):
+    """Match an exact NUL-delimited BOL_HOME entry."""
+    target = b"BOL_HOME=" + os.fsencode(str(Path(profile_dir).resolve()))
+    return target in environ.split(b"\0")
+
+
+def profile_processes(profile_dir):
+    """Return live PIDs running BedrockOnLinux with this exact BOL_HOME."""
+    found = []
+    for pdir in Path("/proc").glob("[0-9]*"):
+        try:
+            if _environ_uses_profile_home(
+                    pdir.joinpath("environ").read_bytes(), profile_dir):
+                pid = int(pdir.name)
+                if pid != os.getpid():
+                    found.append(pid)
+        except Exception:
+            continue
+    return sorted(set(found))
+
+
+def require_profile_idle(profile_dir, action="modify profile"):
+    """Fail before a profile mutation while game or launcher processes are live."""
+    p_dir = Path(profile_dir)
+    pfx = p_dir / "compatdata" / "pfx"
+    if pfx.is_dir():
+        from .prefix import prefix_processes
+        live_wine = prefix_processes(pfx)
+        if live_wine:
+            raise BolError(
+                f"Cannot {action}: {len(live_wine)} Wine/Proton process(es) still "
+                "use this profile. Close Minecraft or use 'Force stop Minecraft' first."
+            )
+
+    lock_path = p_dir / ".launch.lock"
+    if lock_path.exists():
+        try:
+            lock_fd = os.open(lock_path, os.O_RDWR, 0o600)
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError as exc:
+                raise BolError(
+                    f"Cannot {action}: a game session or preparation task is "
+                    "currently active in this profile. Close Minecraft first."
+                ) from exc
+            finally:
+                os.close(lock_fd)
+        except OSError:
+            pass
+
+    live_gui = profile_processes(p_dir)
+    if live_gui:
+        raise BolError(
+            f"Cannot {action}: {len(live_gui)} launcher window(s) are currently "
+            "open for this profile. Close those windows first."
+        )
+
+
 def create_profile(name, base_data=None):
     """Create an account/prefix-isolated profile while sharing large assets."""
     display = str(name).strip()
     slug = profile_slug(display)
+    if slug == "default":
+        raise BolError("The name 'Default' is reserved for the main installation root.")
     base = _profile_base(base_data)
     root = profiles_root(base)
     profile_dir = root / slug
@@ -92,27 +152,31 @@ def create_profile(name, base_data=None):
         except OSError:
             pass
         fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        if profile_dir.exists():
+            metadata_path = _metadata_path(profile_dir)
+            if metadata_path.exists():
+                try:
+                    existing = json.loads(
+                        metadata_path.read_text(encoding="utf-8")
+                    )
+                    if existing.get("name") == display:
+                        return profile_dir
+                    existing_name = existing.get("name", "another profile")
+                except Exception:
+                    existing_name = "another profile"
+                raise BolError(
+                    f"Profile identifier '{slug}' is already used by "
+                    f"'{existing_name}'."
+                )
+            raise BolError(
+                f"A profile named '{display}' already exists."
+            )
+
         profile_dir.mkdir(mode=0o700, exist_ok=True)
         try:
             os.chmod(profile_dir, 0o700)
         except OSError:
             pass
-
-        metadata_path = _metadata_path(profile_dir)
-        if metadata_path.exists():
-            try:
-                existing = json.loads(
-                    metadata_path.read_text(encoding="utf-8")
-                )
-            except Exception as exc:
-                raise BolError(
-                    f"Profile metadata is unreadable: {metadata_path}"
-                ) from exc
-            if existing.get("name") != display:
-                raise BolError(
-                    f"Profile identifier '{slug}' is already used by "
-                    f"'{existing.get('name', 'another profile')}'."
-                )
 
         for directory in _SHARED_DIRS:
             _ensure_shared_link(profile_dir, base, directory)
@@ -128,7 +192,7 @@ def create_profile(name, base_data=None):
                 stream.flush()
                 os.fsync(stream.fileno())
             os.chmod(staged, 0o600)
-            os.replace(staged, metadata_path)
+            os.replace(staged, _metadata_path(profile_dir))
         finally:
             staged.unlink(missing_ok=True)
         return profile_dir
@@ -153,15 +217,19 @@ def list_profiles(base_data=None):
     return found
 
 
-def delete_profile(name, base_data=None):
+def delete_profile(name, base_data=None, applications_dir=None):
     """Delete an isolated profile directory and its shortcuts."""
     display = str(name).strip()
     slug = profile_slug(display)
+    if slug == "default":
+        raise BolError("The main 'Default' profile cannot be deleted.")
     base = _profile_base(base_data)
     root = profiles_root(base)
     profile_dir = root / slug
     if not profile_dir.is_dir():
         raise BolError(f"Profile '{display}' does not exist.")
+
+    require_profile_idle(profile_dir, f"delete profile '{display}'")
 
     for item in profile_dir.iterdir():
         if item.is_symlink():
@@ -172,33 +240,101 @@ def delete_profile(name, base_data=None):
 
     shutil.rmtree(profile_dir)
 
-    apps = XDG_DATA_HOME / "applications"
+    apps = Path(applications_dir or (XDG_DATA_HOME / "applications"))
     for pattern in (f"{APP}-profile-{slug}.desktop", f"{APP}-play-{slug}.desktop"):
         (apps / pattern).unlink(missing_ok=True)
     return True
 
 
-def rename_profile(old_name, new_name, base_data=None):
-    """Rename the display name of an existing profile."""
+def rename_profile(old_name, new_name, base_data=None, applications_dir=None):
+    """Rename the display name and directory of an existing profile."""
     old_display = str(old_name).strip()
     old_slug = profile_slug(old_display)
+    if old_slug == "default":
+        raise BolError("The main 'Default' profile cannot be renamed.")
+
     new_display = str(new_name).strip()
-    profile_slug(new_display)
+    new_slug = profile_slug(new_display)
+    if new_slug == "default":
+        raise BolError("The name 'Default' is reserved for the main installation root.")
 
     base = _profile_base(base_data)
     root = profiles_root(base)
-    profile_dir = root / old_slug
-    if not profile_dir.is_dir():
+    old_dir = root / old_slug
+    new_dir = root / new_slug
+
+    if not old_dir.is_dir():
         raise BolError(f"Profile '{old_display}' does not exist.")
 
-    meta_path = _metadata_path(profile_dir)
+    if new_slug != old_slug and new_dir.exists():
+        raise BolError(f"A profile named '{new_display}' already exists.")
+
+    require_profile_idle(old_dir, f"rename profile '{old_display}'")
+
+    if new_slug != old_slug:
+        old_dir.rename(new_dir)
+        target_dir = new_dir
+    else:
+        target_dir = old_dir
+
+    fd, staged_name = tempfile.mkstemp(
+        prefix=".profile-", suffix=".json", dir=target_dir
+    )
+    staged = Path(staged_name)
     try:
-        data = json.loads(meta_path.read_text(encoding="utf-8"))
-    except Exception:
-        data = {"slug": old_slug}
-    data["name"] = new_display
-    meta_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
-    return profile_dir
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            json.dump({"name": new_display, "slug": new_slug}, stream, indent=2)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.chmod(staged, 0o600)
+        os.replace(staged, _metadata_path(target_dir))
+    finally:
+        staged.unlink(missing_ok=True)
+
+    apps = Path(applications_dir or (XDG_DATA_HOME / "applications"))
+    old_prof_desktop = apps / f"{APP}-profile-{old_slug}.desktop"
+    old_play_desktop = apps / f"{APP}-play-{old_slug}.desktop"
+
+    if new_slug != old_slug:
+        had_prof_desktop = old_prof_desktop.exists()
+        had_play_desktop = old_play_desktop.exists()
+        old_prof_desktop.unlink(missing_ok=True)
+        old_play_desktop.unlink(missing_ok=True)
+        if had_prof_desktop and profile_shortcuts_supported():
+            try:
+                write_profile_shortcut(
+                    new_display, profile_dir=target_dir, applications_dir=apps
+                )
+            except Exception:
+                pass
+        if had_play_desktop and profile_shortcuts_supported():
+            try:
+                write_play_shortcut(
+                    profile_name=new_display, profile_dir=target_dir,
+                    applications_dir=apps
+                )
+            except Exception:
+                pass
+    else:
+        if old_prof_desktop.exists() and profile_shortcuts_supported():
+            try:
+                write_profile_shortcut(
+                    new_display, profile_dir=target_dir, applications_dir=apps
+                )
+            except Exception:
+                pass
+        if old_play_desktop.exists() and profile_shortcuts_supported():
+            try:
+                write_play_shortcut(
+                    profile_name=new_display, profile_dir=target_dir,
+                    applications_dir=apps
+                )
+            except Exception:
+                pass
+
+    return target_dir
+
 
 
 def _desktop_quote(value):

--- a/bol/profiles.py
+++ b/bol/profiles.py
@@ -411,8 +411,9 @@ def relaunch_with_profile(profile_path=None, base_data=None, executable=None):
         subprocess.Popen(args, env=env)
         sys.exit(0)
 
+
 def open_profile_window(profile_path=None, base_data=None, executable=None):
-    """Spawn a new launcher GUI window for the target profile without closing the current one."""
+    """Spawn a new launcher GUI window for the target profile."""
     import subprocess
     from .config import DEFAULT_DATA
     base_root = _profile_base(base_data)
@@ -431,4 +432,13 @@ def open_profile_window(profile_path=None, base_data=None, executable=None):
     else:
         args = [exe, "gui"]
 
-    return subprocess.Popen(args, env=env)
+    return subprocess.Popen(
+        args,
+        env=env,
+        start_new_session=True,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+

--- a/bol/profiles.py
+++ b/bol/profiles.py
@@ -410,3 +410,25 @@ def relaunch_with_profile(profile_path=None, base_data=None, executable=None):
         import subprocess
         subprocess.Popen(args, env=env)
         sys.exit(0)
+
+def open_profile_window(profile_path=None, base_data=None, executable=None):
+    """Spawn a new launcher GUI window for the target profile without closing the current one."""
+    import subprocess
+    from .config import DEFAULT_DATA
+    base_root = _profile_base(base_data)
+    env = dict(os.environ)
+    if profile_path:
+        env["BOL_HOME"] = str(Path(profile_path).expanduser().resolve())
+    else:
+        if base_root.resolve() != DEFAULT_DATA.resolve():
+            env["BOL_HOME"] = str(base_root.resolve())
+        else:
+            env.pop("BOL_HOME", None)
+
+    exe = launcher_executable(explicit=executable)
+    if exe.endswith(".py") or Path(exe).name == APP:
+        args = [sys.executable, exe, "gui"]
+    else:
+        args = [exe, "gui"]
+
+    return subprocess.Popen(args, env=env)

--- a/bol/profiles.py
+++ b/bol/profiles.py
@@ -141,7 +141,7 @@ def list_profiles(base_data=None):
     if not root.is_dir():
         return []
     found = []
-    for metadata in sorted(root.glob("*/profile.json")):
+    for metadata in root.glob("*/profile.json"):
         try:
             item = json.loads(metadata.read_text(encoding="utf-8"))
             item["path"] = str(metadata.parent)
@@ -149,7 +149,56 @@ def list_profiles(base_data=None):
                 found.append(item)
         except Exception:
             continue
+    found.sort(key=lambda p: str(p.get("name", "")).lower())
     return found
+
+
+def delete_profile(name, base_data=None):
+    """Delete an isolated profile directory and its shortcuts."""
+    display = str(name).strip()
+    slug = profile_slug(display)
+    base = _profile_base(base_data)
+    root = profiles_root(base)
+    profile_dir = root / slug
+    if not profile_dir.is_dir():
+        raise BolError(f"Profile '{display}' does not exist.")
+
+    for item in profile_dir.iterdir():
+        if item.is_symlink():
+            try:
+                item.unlink()
+            except OSError:
+                pass
+
+    shutil.rmtree(profile_dir)
+
+    apps = XDG_DATA_HOME / "applications"
+    for pattern in (f"{APP}-profile-{slug}.desktop", f"{APP}-play-{slug}.desktop"):
+        (apps / pattern).unlink(missing_ok=True)
+    return True
+
+
+def rename_profile(old_name, new_name, base_data=None):
+    """Rename the display name of an existing profile."""
+    old_display = str(old_name).strip()
+    old_slug = profile_slug(old_display)
+    new_display = str(new_name).strip()
+    profile_slug(new_display)
+
+    base = _profile_base(base_data)
+    root = profiles_root(base)
+    profile_dir = root / old_slug
+    if not profile_dir.is_dir():
+        raise BolError(f"Profile '{old_display}' does not exist.")
+
+    meta_path = _metadata_path(profile_dir)
+    try:
+        data = json.loads(meta_path.read_text(encoding="utf-8"))
+    except Exception:
+        data = {"slug": old_slug}
+    data["name"] = new_display
+    meta_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return profile_dir
 
 
 def _desktop_quote(value):
@@ -305,3 +354,59 @@ def profile_launch_command(profile_dir, executable=None):
 def play_launch_command(profile_dir=None, executable=None):
     """Shell-display form of the launcher-free launch, for Steam."""
     return _shell_command("play", profile_dir, executable)
+
+
+def current_profile_info(base_data=None):
+    """Return metadata for the active profile, or 'Default' for the main root."""
+    base = Path(DATA if base_data is None else base_data).expanduser().resolve()
+    if base.parent.name == "profiles":
+        try:
+            metadata = json.loads(_metadata_path(base).read_text(encoding="utf-8"))
+            if metadata.get("name") and metadata.get("slug") == base.name:
+                return {
+                    "name": metadata["name"],
+                    "slug": metadata["slug"],
+                    "path": str(base),
+                }
+        except (OSError, ValueError, TypeError):
+            pass
+    return {
+        "name": "Default",
+        "slug": "default",
+        "path": None,
+    }
+
+
+def current_profile_name(base_data=None):
+    """Return the display name of the currently active profile."""
+    return current_profile_info(base_data)["name"]
+
+
+def relaunch_with_profile(profile_path=None, base_data=None, executable=None):
+    """Relaunch the launcher GUI in the target profile's environment."""
+    from .config import DEFAULT_DATA
+    base_root = _profile_base(base_data)
+    env = dict(os.environ)
+    if profile_path:
+        env["BOL_HOME"] = str(Path(profile_path).expanduser().resolve())
+    else:
+        if base_root.resolve() != DEFAULT_DATA.resolve():
+            env["BOL_HOME"] = str(base_root.resolve())
+        else:
+            env.pop("BOL_HOME", None)
+
+    exe = launcher_executable(explicit=executable)
+    if exe.endswith(".py") or Path(exe).name == APP:
+        args = [sys.executable, exe, "gui"]
+    else:
+        args = [exe, "gui"]
+
+    os.environ.clear()
+    os.environ.update(env)
+
+    try:
+        os.execv(args[0], args)
+    except OSError:
+        import subprocess
+        subprocess.Popen(args, env=env)
+        sys.exit(0)

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -403,6 +403,7 @@ def test_relaunch_with_profile_sets_bol_home_and_execs(tmp_path):
             mock_execv.assert_called_once()
             assert os.environ["BOL_HOME"] == str(custom_root.resolve())
 
+
 def test_open_profile_window_spawns_process(tmp_path):
     profile = tmp_path / "custom_profile"
     with mock.patch("subprocess.Popen") as mock_popen, \
@@ -412,3 +413,23 @@ def test_open_profile_window_spawns_process(tmp_path):
         args, kwargs = mock_popen.call_args
         assert args[0] == ["/bin/bol", "gui"]
         assert kwargs["env"]["BOL_HOME"] == str(profile.resolve())
+        assert kwargs.get("start_new_session") is True
+        assert kwargs.get("stdout") == subprocess.DEVNULL
+        assert kwargs.get("stderr") == subprocess.DEVNULL
+        assert kwargs.get("stdin") == subprocess.DEVNULL
+
+
+def test_open_profile_window_with_default_profile(tmp_path):
+    custom_root = tmp_path / "sandbox"
+    with mock.patch("subprocess.Popen") as mock_popen, \
+         mock.patch("bol.profiles.launcher_executable", return_value="/bin/bol"):
+        open_profile_window(None, base_data=custom_root)
+        mock_popen.assert_called_once()
+        args, kwargs = mock_popen.call_args
+        assert args[0] == ["/bin/bol", "gui"]
+        assert kwargs["env"]["BOL_HOME"] == str(custom_root.resolve())
+        assert kwargs.get("start_new_session") is True
+        assert kwargs.get("stdout") == subprocess.DEVNULL
+        assert kwargs.get("stderr") == subprocess.DEVNULL
+        assert kwargs.get("stdin") == subprocess.DEVNULL
+

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -24,6 +24,7 @@ from bol.profiles import (
     profile_launch_command,
     profile_slug,
     relaunch_with_profile,
+    open_profile_window,
     rename_profile,
     require_profile_shortcuts_supported,
     require_shortcuts_supported,
@@ -402,3 +403,12 @@ def test_relaunch_with_profile_sets_bol_home_and_execs(tmp_path):
             mock_execv.assert_called_once()
             assert os.environ["BOL_HOME"] == str(custom_root.resolve())
 
+def test_open_profile_window_spawns_process(tmp_path):
+    profile = tmp_path / "custom_profile"
+    with mock.patch("subprocess.Popen") as mock_popen, \
+         mock.patch("bol.profiles.launcher_executable", return_value="/bin/bol"):
+        open_profile_window(profile)
+        mock_popen.assert_called_once()
+        args, kwargs = mock_popen.call_args
+        assert args[0] == ["/bin/bol", "gui"]
+        assert kwargs["env"]["BOL_HOME"] == str(profile.resolve())

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -15,11 +15,16 @@ import pytest
 from bol.log import BolError
 from bol.profiles import (
     create_profile,
+    current_profile_info,
+    current_profile_name,
+    delete_profile,
     launcher_executable,
     list_profiles,
     play_launch_command,
     profile_launch_command,
     profile_slug,
+    relaunch_with_profile,
+    rename_profile,
     require_profile_shortcuts_supported,
     require_shortcuts_supported,
     write_play_shortcut,
@@ -119,10 +124,11 @@ def test_invalid_profile_name_is_rejected(name):
 
 
 def test_profiles_are_listed_from_metadata(tmp_path):
-    create_profile("Second", tmp_path)
-    create_profile("First", tmp_path)
+    create_profile("Zeta", tmp_path)
+    create_profile("alpha", tmp_path)
+    create_profile("Beta", tmp_path)
     items = list_profiles(tmp_path)
-    assert {item["name"] for item in items} == {"First", "Second"}
+    assert [item["name"] for item in items] == ["alpha", "Beta", "Zeta"]
     assert all(Path(item["path"]).is_dir() for item in items)
 
 
@@ -333,3 +339,66 @@ def test_flatpak_play_shortcut_is_refused_with_a_runnable_alternative(
     assert "cannot be written from the Flatpak sandbox" in message
     # A refusal with no way forward is what sends users to the issue tracker.
     assert "flatpak run io.github.wyze3306.BedrockOnLinux play" in message
+
+
+def test_delete_profile_removes_folder_and_shortcuts(tmp_path):
+    base = tmp_path / "data"
+    profile = create_profile("To Delete", base)
+    assert profile.is_dir()
+    assert (profile / "games").is_symlink()
+
+    delete_profile("To Delete", base)
+    assert not profile.exists()
+    assert (base / "games").is_dir()  # Shared assets must remain intact
+
+
+def test_rename_profile_updates_metadata_name(tmp_path):
+    base = tmp_path / "data"
+    profile = create_profile("Old Name", base)
+    rename_profile("Old Name", "New Name", base)
+
+    meta = json.loads((profile / "profile.json").read_text(encoding="utf-8"))
+    assert meta["name"] == "New Name"
+    assert meta["slug"] == "old-name"
+
+
+def test_current_profile_info_on_default_data(tmp_path):
+    with mock.patch("bol.profiles.DATA", tmp_path / "default_data"):
+        info = current_profile_info()
+        assert info["name"] == "Default"
+        assert info["slug"] == "default"
+        assert info["path"] is None
+        assert current_profile_name() == "Default"
+
+
+def test_current_profile_info_in_managed_profile(tmp_path):
+    base = tmp_path / "data"
+    alice = create_profile("Alice", base)
+    with mock.patch("bol.profiles.DATA", alice):
+        info = current_profile_info()
+        assert info["name"] == "Alice"
+        assert info["slug"] == "alice"
+        assert info["path"] == str(alice)
+        assert current_profile_name() == "Alice"
+
+
+def test_relaunch_with_profile_sets_bol_home_and_execs(tmp_path):
+    profile = tmp_path / "custom_profile"
+    with mock.patch.dict(os.environ, {}, clear=True):
+        with mock.patch("os.execv") as mock_execv, \
+             mock.patch("bol.profiles.launcher_executable", return_value="/bin/bol"):
+            relaunch_with_profile(profile)
+            mock_execv.assert_called_once()
+            args = mock_execv.call_args[0]
+            assert os.environ["BOL_HOME"] == str(profile.resolve())
+            assert args[1] == ["/bin/bol", "gui"]
+
+    # When switching to Default with a custom base root (e.g. dev sandbox)
+    custom_root = tmp_path / "sandbox"
+    with mock.patch.dict(os.environ, {}, clear=True):
+        with mock.patch("os.execv") as mock_execv, \
+             mock.patch("bol.profiles.launcher_executable", return_value="/bin/bol"):
+            relaunch_with_profile(None, base_data=custom_root)
+            mock_execv.assert_called_once()
+            assert os.environ["BOL_HOME"] == str(custom_root.resolve())
+

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -353,14 +353,76 @@ def test_delete_profile_removes_folder_and_shortcuts(tmp_path):
     assert (base / "games").is_dir()  # Shared assets must remain intact
 
 
-def test_rename_profile_updates_metadata_name(tmp_path):
+def test_rename_profile_renames_folder_and_shortcuts(tmp_path):
     base = tmp_path / "data"
+    apps = tmp_path / "applications"
     profile = create_profile("Old Name", base)
-    rename_profile("Old Name", "New Name", base)
+    write_profile_shortcut("Old Name", profile_dir=profile, applications_dir=apps)
+    write_play_shortcut("Old Name", profile_dir=profile, applications_dir=apps)
 
-    meta = json.loads((profile / "profile.json").read_text(encoding="utf-8"))
+    new_profile = rename_profile("Old Name", "New Name", base, applications_dir=apps)
+    assert not profile.exists()
+    assert new_profile.exists()
+    assert new_profile.name == "new-name"
+
+    meta = json.loads((new_profile / "profile.json").read_text(encoding="utf-8"))
     assert meta["name"] == "New Name"
-    assert meta["slug"] == "old-name"
+    assert meta["slug"] == "new-name"
+
+    assert not (apps / "bedrock-on-linux-profile-old-name.desktop").exists()
+    assert not (apps / "bedrock-on-linux-play-old-name.desktop").exists()
+    assert (apps / "bedrock-on-linux-profile-new-name.desktop").exists()
+    assert (apps / "bedrock-on-linux-play-new-name.desktop").exists()
+
+
+def test_create_profile_reserved_default_rejected(tmp_path):
+    with pytest.raises(BolError) as err:
+        create_profile("Default", tmp_path)
+    assert "reserved" in str(err.value)
+
+
+def test_rename_profile_reserved_default_rejected(tmp_path):
+    base = tmp_path / "data"
+    create_profile("Player", base)
+    with pytest.raises(BolError) as err:
+        rename_profile("Player", "Default", base)
+    assert "reserved" in str(err.value)
+
+
+def test_rename_profile_duplicate_name_rejected(tmp_path):
+    base = tmp_path / "data"
+    create_profile("Alice", base)
+    create_profile("Bob", base)
+    with pytest.raises(BolError) as err:
+        rename_profile("Alice", "Bob", base)
+    assert "already exists" in str(err.value)
+
+
+def test_delete_profile_reserved_default_rejected(tmp_path):
+    with pytest.raises(BolError) as err:
+        delete_profile("Default", tmp_path)
+    assert "cannot be deleted" in str(err.value)
+
+
+def test_delete_profile_blocked_when_active_processes(tmp_path):
+    base = tmp_path / "data"
+    profile = create_profile("Active Player", base)
+    with mock.patch("bol.profiles.profile_processes", return_value=[12345]):
+        with pytest.raises(BolError) as err:
+            delete_profile("Active Player", base)
+        assert "launcher window(s) are currently open" in str(err.value)
+    assert profile.exists()
+
+
+def test_rename_profile_blocked_when_active_processes(tmp_path):
+    base = tmp_path / "data"
+    profile = create_profile("Active Player", base)
+    with mock.patch("bol.profiles.profile_processes", return_value=[12345]):
+        with pytest.raises(BolError) as err:
+            rename_profile("Active Player", "New Player", base)
+        assert "launcher window(s) are currently open" in str(err.value)
+    assert profile.exists()
+
 
 
 def test_current_profile_info_on_default_data(tmp_path):


### PR DESCRIPTION
Currently, switching between isolated Xbox account profiles requires launching from separate desktop shortcuts or running with `BOL_HOME` in the terminal.

This PR adds an in-launcher profile switcher so users can manage and switch profiles directly from the UI:

- **Profile button & dropdown in top bar**: Shows current active profile next to the account card. Clicking it lets you quickly switch profiles, create a new one, or open the manager.
- **Manage Profiles dialog**: Allows renaming profiles, deleting unused profiles (with confirmation and symlink cleanup), and opening the profile directory in file manager.
- **Profile helpers**: Added `delete_profile`, `rename_profile`, and `current_profile_info`.
- **Alphabetical sorting**: Custom profiles are sorted alphabetically by display name.
- **Tests**: Added unit tests covering profile detection, deletion, renaming, and relaunching.