### PR TITLE
Fix: remove stray `env` kwarg from wrap_encrypted_launch() call

### DIFF
--- a/bol/launch.py
+++ b/bol/launch.py
@@ -650,8 +650,9 @@ def _launch_once(lock_fds=(), on_started=None):
     if encrypted_exe:
         # Must wrap before gamescope: gamescope has to stay outermost so it
         # owns the compositor the game renders into.
-        cmd = xodus.wrap_encrypted_launch(cmd, Path(gd), DATA / "run", env=env)
-    if use_gamescope:
+        cmd = xodus.wrap_encrypted_launch(cmd, Path(gd), DATA / "run")
+        
+        if use_gamescope:
         if gs_opt and not env_flag(gs_opt):
             gs_argv = ["gamescope"] + shlex.split(gs_opt)
         else:

--- a/bol/launch.py
+++ b/bol/launch.py
@@ -651,8 +651,7 @@ def _launch_once(lock_fds=(), on_started=None):
         # Must wrap before gamescope: gamescope has to stay outermost so it
         # owns the compositor the game renders into.
         cmd = xodus.wrap_encrypted_launch(cmd, Path(gd), DATA / "run")
-        
-        if use_gamescope:
+    if use_gamescope:
         if gs_opt and not env_flag(gs_opt):
             gs_argv = ["gamescope"] + shlex.split(gs_opt)
         else:


### PR DESCRIPTION
`_launch_once()` in `bol/launch.py` was calling:

    cmd = xodus.wrap_encrypted_launch(cmd, Path(gd), DATA / "run", env=env)

but `xodus.wrap_encrypted_launch()` only accepts `(argv, game_dir, work_dir,
launcher_path=None)` — there's no `env` parameter. This raised:

    wrap_encrypted_launch() got an unexpected keyword argument 'env'

on every launch of a build with an encrypted executable (i.e. every normal
GDK title via Xodus), right after Xbox Live pre-auth completes.

`env` isn't actually needed inside `wrap_encrypted_launch()` — it only
builds the wrapper script and returns a new argv; the real environment is
passed separately to `subprocess.Popen(cmd, env=env, ...)` later in the
same function. So the fix is just to drop the stray keyword argument at
the call site, with no change to behavior.

## Change
- `bol/launch.py`: drop `env=env` from the `xodus.wrap_encrypted_launch(...)` call.

## Testing
- Confirmed the launch path reaches `subprocess.Popen` and starts the game
  instead of erroring out before the process is created.