### PR TITLE
fix(engine): re-pin wow64-archs-native16 archive (55f29ad → 955ecfe) — hotfix for v2.2.2

### DIFF
--- a/bol/config.py
+++ b/bol/config.py
@@ -100,7 +100,7 @@ WINEGDK_BUILD_REV = "wow64-archs-native16"
 # unset pin here makes _verify_engine_archive() refuse every candidate rather
 # than fall back. Produced by the reviewed build-engine.yml run of this branch,
 # which refuses any archive that does not reproduce these bytes.
-WINEGDK_ARCHIVE_SHA256 = "55f29ad109dbb28e5b4f1fd3b527ff886b75bbd4169f89ac6c7bcdbe503c4ec5"
+WINEGDK_ARCHIVE_SHA256 = "955ecfe33a655927f9f748aa62fe154ad7f6e899cb61c4f50748af8f2e155c34"
 # Build workflows verify this deterministic intermediate before reusing it.
 WINEGDK_PREFIX_SHA256 = "bfbb08107e7aa16842cf12814013a1cb94acd5a1c2fe8eaec24a401c4b57fc09"
 

--- a/bol/config.py
+++ b/bol/config.py
@@ -102,7 +102,7 @@ WINEGDK_BUILD_REV = "wow64-archs-native16"
 # which refuses any archive that does not reproduce these bytes.
 WINEGDK_ARCHIVE_SHA256 = "55f29ad109dbb28e5b4f1fd3b527ff886b75bbd4169f89ac6c7bcdbe503c4ec5"
 # Build workflows verify this deterministic intermediate before reusing it.
-WINEGDK_PREFIX_SHA256 = "eeb5079fa9736f2d5b71d95d72d64fd56fe51b5be7df220d0a535d2897165dde"
+WINEGDK_PREFIX_SHA256 = "bfbb08107e7aa16842cf12814013a1cb94acd5a1c2fe8eaec24a401c4b57fc09"
 
 SELF_REPO = WINEGDK_PREBUILT_REPO
 


### PR DESCRIPTION
### Problem

In `v2.2.2` (tag `3b2ea18`, released 2026-08-22 09:37) `bol/config.py:103` still pins:

```python
WINEGDK_ARCHIVE_SHA256 = "55f29ad109dbb28e5b4f1fd3b527ff886b75bbd4169f89ac6c7bcdbe503c4ec5"
WINEGDK_PREFIX_SHA256 = "eeb5079fa9736f2d5b71d95d72d64fd56fe51b5be7df220d0a535d2897165dde"
```

But the published asset at `engine-wow64-archs-native16` (published 2026-08-17, digest `sha256:955ecfe33a655927f9f748aa62fe154ad7f6e899cb61c4f50748af8f2e155c34`) was rebuilt 2026-08-19/20 to include `winewayland.drv` (fix #180, commit 7307754). `scripts/package-engine.sh` rejects a tree without that driver, so every `release.yml` since 2026-08-20 fails and the reproducible prefix changed.

Result for Flatpak/AppImage users on 2.2.2:

```
warn Prebuilt engine rejected (engine archive SHA-256 mismatch (expected 55f29ad..., got 955ecfe...)) — keeping the installed engine.
error No verified game-engine archive is available for wow64-archs-native16.
```

`bol/winegdk.py:83` `_verify_engine_archive()` rejects any download because the pin mismatches; with no engine installed the launcher aborts at `bol/winegdk.py:376` via `die()`. This is exactly the failure reported in #208.

### Fix

Cherry-pick from `main` (already on `main` post-2.2.2, not yet released):

* `8fff566` — `engine: re-pin the WineGDK prefix onto a build that has its own Wayland driver` (`WINEGDK_PREFIX_SHA256` → `bfbb08107e7aa16842cf12814013a1cb94acd5a1c2fe8eaec24a401c4b57fc09`)
* `8221f79` — `engine: re-pin the engine archive onto the Wayland-correct prefix` (`WINEGDK_ARCHIVE_SHA256` → `955ecfe33a655927f9f748aa62fe154ad7f6e899cb61c4f50748af8f2e155c34`)

### Verification

* `gh api repos/Wyze3306/BedrockOnLinux/releases/tags/engine-wow64-archs-native16` digest `955ecfe...` now matches the updated pin.
* `pytest tests/test_winegdk.py tests/test_vkd3d.py` — 24 + 32 tests pass (incl. `test_archive_hash_mismatch_keeps_current_engine` `tests/test_winegdk.py:290`).
* Branch base: `v2.2.2` reproduces the bug → this PR is the hotfix.
* Flatpak doctor after patched engine install: `fast sync: OK` `wayland drv: OK`.

### Release note

`main` already contains both pins. This PR is the hotfix to cut `v2.2.3`; alternatively release `main` as `2.2.3` (bump `VERSION` `bol/config.py:9`).

Closes #208
