### PR TITLE
Add automatic DLL injection support

### DIFF
--- a/bol/gui.py
+++ b/bol/gui.py
@@ -961,12 +961,6 @@ class LaunchWorker(QThread):
                 elif action == "step-aside":
                     self.step_aside.emit()
 
-                s = load_settings()
-                if s.get("injector_auto_enable", False):
-                    from .inject import perform_auto_inject
-                    import threading
-                    threading.Thread(target=perform_auto_inject, args=(s,), daemon=True).start()
-
             try:
                 launch(on_started=on_started)
             finally:
@@ -2500,7 +2494,10 @@ class MainWindow(QMainWindow):
 
         delay_layout = QHBoxLayout()
         delay_label = QLabel("Injection delay (seconds):")
-        delay_label.setToolTip("Wait this many seconds after the process starts before injecting (used as a fallback if the window isn't detected).")
+        delay_label.setToolTip(
+            "Wait at least this long after the game starts before injecting. "
+            "Injection also waits for the game's window, so a DLL never loads "
+            "into a game that has not opened yet.")
         delay_layout.addWidget(delay_label)
 
         self.delay_spin = QSpinBox()

--- a/bol/gui.py
+++ b/bol/gui.py
@@ -25,7 +25,7 @@ from PySide6.QtWidgets import (
     QAbstractButton, QApplication, QButtonGroup, QDialog, QFileDialog, QFrame,
     QHBoxLayout, QInputDialog, QLabel,
     QLineEdit, QListWidget, QListWidgetItem, QMainWindow, QMessageBox,
-    QPlainTextEdit, QProgressBar, QPushButton, QScrollArea, QStackedWidget, QTabWidget, QTextBrowser, QTextEdit,
+    QPlainTextEdit, QProgressBar, QPushButton, QScrollArea, QSpinBox, QStackedWidget, QTabWidget, QTextBrowser, QTextEdit,
     QToolButton, QVBoxLayout, QWidget,
 )
 
@@ -960,6 +960,12 @@ class LaunchWorker(QThread):
                     self.close_window.emit()
                 elif action == "step-aside":
                     self.step_aside.emit()
+
+                s = load_settings()
+                if s.get("injector_auto_enable", False):
+                    from .inject import perform_auto_inject
+                    import threading
+                    threading.Thread(target=perform_auto_inject, args=(s,), daemon=True).start()
 
             try:
                 launch(on_started=on_started)
@@ -2452,6 +2458,54 @@ class MainWindow(QMainWindow):
                                tip="Open the folder holding your worlds, templates "
                                    "and screenshots in your file manager."))
 
+        injector_sec = card_section(v, "Injector Settings")
+
+        self.auto_switch = self._switch(
+            "Auto-inject client DLL on launch",
+            self.settings.get("injector_auto_enable", False),
+            "Automatically inject a DLL when Minecraft starts."
+        )
+        self.auto_switch.toggled.connect(lambda on: self._save_setting("injector_auto_enable", on))
+        injector_sec.addWidget(self.auto_switch)
+
+        self.remote_switch = self._switch(
+            "Remote DLL via URL",
+            self.settings.get("injector_dll_type", "file") == "url",
+            "Toggle between using a local DLL file or downloading one from a URL."
+        )
+        self.remote_switch.toggled.connect(self._on_injector_dll_type_toggled)
+        injector_sec.addWidget(self.remote_switch)
+
+        dll_layout = QHBoxLayout()
+        is_url = self.settings.get("injector_dll_type") == "url"
+        self.dll_input = QLineEdit(
+            self.settings.get("injector_dll_url" if is_url else "injector_dll_path") or ""
+        )
+        self.dll_input.textChanged.connect(self._on_injector_dll_text_changed)
+        dll_layout.addWidget(self.dll_input)
+
+        self.dll_browse_btn = btn("Browse…", self._do_browse_dll, kind="ghost", w=84, h=32,
+                                  tip="Select a DLL file from your computer.")
+        dll_layout.addWidget(self.dll_browse_btn)
+        injector_sec.addLayout(dll_layout)
+
+        delay_layout = QHBoxLayout()
+        delay_label = QLabel("Injection delay (seconds):")
+        delay_label.setToolTip("Wait this many seconds after the process starts before injecting (used as a fallback if the window isn't detected).")
+        delay_layout.addWidget(delay_label)
+
+        self.delay_spin = QSpinBox()
+        self.delay_spin.setRange(0, 60)
+        self.delay_spin.setValue(int(self.settings.get("injector_delay", 5)))
+        self.delay_spin.valueChanged.connect(lambda val: self._save_setting("injector_delay", val))
+        self.delay_spin.setFixedWidth(80)
+        self.delay_spin.setFixedHeight(30)
+        delay_layout.addWidget(self.delay_spin)
+        delay_layout.addStretch(1)
+        injector_sec.addLayout(delay_layout)
+
+        self._update_injector_settings_ui()
+
         shortcuts = card_section(v, "Shortcuts")
         shortcuts.addWidget(tool_row("Create direct launch shortcut (skips this window)…",
                                  self._do_play_shortcut,
@@ -2561,6 +2615,35 @@ class MainWindow(QMainWindow):
         w.done.connect(finished)
         w.failed.connect(failed)
         self._start_worker("inject", w)
+
+    def _on_injector_dll_type_toggled(self, on):
+        dll_type = "url" if on else "file"
+        self._save_setting("injector_dll_type", dll_type)
+        last_val = self.settings.get("injector_dll_url" if on else "injector_dll_path") or ""
+        self.dll_input.setText(last_val)
+        self._update_injector_settings_ui()
+
+    def _on_injector_dll_text_changed(self, text):
+        on = self.remote_switch.isChecked()
+        key = "injector_dll_url" if on else "injector_dll_path"
+        self._save_setting(key, text)
+
+    def _do_browse_dll(self):
+        last = self.settings.get("injector_dll_path") or ""
+        dll, _ = QFileDialog.getOpenFileName(self, "Choose a client .dll to inject",
+                                              str(Path(last).parent) if last else "",
+                                              "Client DLL (*.dll);;All files (*.*)")
+        if dll:
+            self.dll_input.setText(dll)
+            self._save_setting("injector_dll_path", dll)
+
+    def _update_injector_settings_ui(self):
+        is_url = self.remote_switch.isChecked()
+        self.dll_browse_btn.setVisible(not is_url)
+        if is_url:
+            self.dll_input.setPlaceholderText("https://example.com/client.dll")
+        else:
+            self.dll_input.setPlaceholderText("Path to client.dll")
 
     def _do_create_profile_shortcut(self):
         name, ok = QInputDialog.getText(self, "Create account profile",

--- a/bol/gui.py
+++ b/bol/gui.py
@@ -22,7 +22,7 @@ from PySide6.QtCore import (
 )
 from PySide6.QtGui import QColor, QIcon, QPainter, QPixmap
 from PySide6.QtWidgets import (
-    QAbstractButton, QApplication, QButtonGroup, QDialog, QFileDialog, QFrame,
+    QAbstractButton, QApplication, QButtonGroup, QComboBox, QDialog, QFileDialog, QFrame,
     QHBoxLayout, QInputDialog, QLabel,
     QLineEdit, QListWidget, QListWidgetItem, QMainWindow, QMessageBox,
     QPlainTextEdit, QProgressBar, QPushButton, QScrollArea, QSpinBox, QStackedWidget, QTabWidget, QTextBrowser, QTextEdit,
@@ -2468,13 +2468,22 @@ class MainWindow(QMainWindow):
         self.auto_switch.toggled.connect(lambda on: self._save_setting("injector_auto_enable", on))
         injector_sec.addWidget(self.auto_switch)
 
-        self.remote_switch = self._switch(
-            "Remote DLL via URL",
-            self.settings.get("injector_dll_type", "file") == "url",
-            "Toggle between using a local DLL file or downloading one from a URL."
+        mode_layout = QHBoxLayout()
+        mode_label = QLabel("DLL load mode:")
+        mode_label.setToolTip("Choose whether to inject a local DLL or download one from a URL.")
+        mode_layout.addWidget(mode_label)
+
+        self.dll_mode_combo = QComboBox()
+        self.dll_mode_combo.addItem("File", "file")
+        self.dll_mode_combo.addItem("Download", "url")
+        current_mode = self.settings.get("injector_dll_type", "file")
+        self.dll_mode_combo.setCurrentIndex(1 if current_mode == "url" else 0)
+        self.dll_mode_combo.currentIndexChanged.connect(
+            lambda idx: self._on_injector_dll_type_toggled(self.dll_mode_combo.itemData(idx))
         )
-        self.remote_switch.toggled.connect(self._on_injector_dll_type_toggled)
-        injector_sec.addWidget(self.remote_switch)
+        mode_layout.addWidget(self.dll_mode_combo)
+        mode_layout.addStretch(1)
+        injector_sec.addLayout(mode_layout)
 
         dll_layout = QHBoxLayout()
         is_url = self.settings.get("injector_dll_type") == "url"
@@ -2616,15 +2625,15 @@ class MainWindow(QMainWindow):
         w.failed.connect(failed)
         self._start_worker("inject", w)
 
-    def _on_injector_dll_type_toggled(self, on):
-        dll_type = "url" if on else "file"
+    def _on_injector_dll_type_toggled(self, dll_type):
+        dll_type = dll_type if dll_type in ("file", "url") else ("url" if dll_type else "file")
         self._save_setting("injector_dll_type", dll_type)
-        last_val = self.settings.get("injector_dll_url" if on else "injector_dll_path") or ""
+        last_val = self.settings.get("injector_dll_url" if dll_type == "url" else "injector_dll_path") or ""
         self.dll_input.setText(last_val)
         self._update_injector_settings_ui()
 
     def _on_injector_dll_text_changed(self, text):
-        on = self.remote_switch.isChecked()
+        on = self.dll_mode_combo.currentData() == "url"
         key = "injector_dll_url" if on else "injector_dll_path"
         self._save_setting(key, text)
 
@@ -2638,7 +2647,7 @@ class MainWindow(QMainWindow):
             self._save_setting("injector_dll_path", dll)
 
     def _update_injector_settings_ui(self):
-        is_url = self.remote_switch.isChecked()
+        is_url = self.dll_mode_combo.currentData() == "url"
         self.dll_browse_btn.setVisible(not is_url)
         if is_url:
             self.dll_input.setPlaceholderText("https://example.com/client.dll")

--- a/bol/inject.py
+++ b/bol/inject.py
@@ -157,3 +157,96 @@ def run_injector(dll_path):
             f"Details: {LOGS / 'injector.log'}."
         )
     return dll.name
+
+
+def perform_auto_inject(settings):
+    """Wait for Minecraft.Windows.exe to start, detect its window (or use delay),
+    and inject the configured local or remote DLL."""
+    dll_type = settings.get("injector_dll_type", "file")
+    delay = float(settings.get("injector_delay", 5))
+
+    # 1. Resolve DLL path
+    if dll_type == "url":
+        url = settings.get("injector_dll_url", "").strip()
+        if not url:
+            with open(LOGS / "injector.log", "a") as log:
+                log.write("Auto-inject failed: URL is empty.\n")
+            from .log import desktop_notify
+            desktop_notify("Auto-inject failed: DLL URL is empty.", "DLL Injector")
+            return
+        try:
+            dest = CACHE / "downloaded_client.dll"
+            from .util import download
+            download(url, dest, label="Auto-inject DLL")
+            dll_path = dest
+        except Exception as e:
+            with open(LOGS / "injector.log", "a") as log:
+                log.write(f"Auto-inject download failed: {e}\n")
+            from .log import desktop_notify
+            desktop_notify(f"Auto-inject download failed:\n{e}", "DLL Injector")
+            return
+    else:
+        dll_path = settings.get("injector_dll_path", "").strip()
+        if not dll_path:
+            dll_path = settings.get("injector_dll", "").strip()
+        if not dll_path:
+            with open(LOGS / "injector.log", "a") as log:
+                log.write("Auto-inject failed: Local DLL path is empty.\n")
+            from .log import desktop_notify
+            desktop_notify("Auto-inject failed: Local DLL path is empty.", "DLL Injector")
+            return
+        dll_path = Path(dll_path)
+
+    # 2. Wait for Minecraft process to start (up to 30 seconds)
+    started_wait = time.monotonic()
+    process_found = False
+    while time.monotonic() - started_wait < 30:
+        if _mc_running():
+            process_found = True
+            break
+        time.sleep(0.2)
+
+    if not process_found:
+        with open(LOGS / "injector.log", "a") as log:
+            log.write("Auto-inject failed: Minecraft process did not start within 30s.\n")
+        from .log import desktop_notify
+        desktop_notify("Auto-inject failed: Minecraft process did not start.", "DLL Injector")
+        return
+
+    # Process is running! Record start time.
+    process_start_time = time.monotonic()
+    safety_buffer = 1.5
+
+    # 3. Poll for presentable window or wait for delay
+    while True:
+        elapsed = time.monotonic() - process_start_time
+
+        try:
+            from .x11 import find_presentable_window
+            has_window = find_presentable_window("minecraft.windows.exe")
+        except Exception:
+            has_window = False
+
+        if has_window:
+            time.sleep(safety_buffer)
+            break
+
+        if elapsed >= delay:
+            break
+
+        if not _mc_running():
+            return
+
+        time.sleep(0.1)
+
+    # 4. Perform injection
+    try:
+        name = run_injector(dll_path)
+        from .log import desktop_notify
+        desktop_notify(f"Injected {name} into Minecraft. ✓", "DLL Injector")
+    except Exception as e:
+        with open(LOGS / "injector.log", "a") as log:
+            log.write(f"Auto-inject failed: {e}\n")
+        from .log import desktop_notify
+        desktop_notify(f"Could not inject:\n{e}", "DLL Injector")
+

--- a/bol/inject.py
+++ b/bol/inject.py
@@ -4,15 +4,17 @@ Flatpak is unsupported because its sandbox isolates the game's wineserver.
 """
 # SPDX-License-Identifier: MIT
 
+import hashlib
 import os
 import pkgutil
 import subprocess
 import tempfile
+import threading
 import time
 from pathlib import Path
 
 from .config import CACHE, LOGS
-from .log import BolError
+from .log import BolError, desktop_notify
 from .prefix import _mc_running, active_prefix, prefix_processes
 from .proton import proton_path
 
@@ -159,94 +161,142 @@ def run_injector(dll_path):
     return dll.name
 
 
-def perform_auto_inject(settings):
-    """Wait for Minecraft.Windows.exe to start, detect its window (or use delay),
-    and inject the configured local or remote DLL."""
-    dll_type = settings.get("injector_dll_type", "file")
-    delay = float(settings.get("injector_delay", 5))
+# The game's X window exists long before its main menu does, so a window
+# sighting is a floor for the wait and never a shortcut through it: what the
+# player configured is what decides when the DLL goes in.
+_AUTO_INJECT_WINDOW_SETTLE = 1.5
+# A Wayland-backend session gives the game no X window at all, so the wait
+# for one is capped rather than open-ended.
+_AUTO_INJECT_WINDOW_CEILING = 30.0
+_AUTO_INJECT_PROCESS_CEILING = 30.0
+_AUTO_INJECT_POLL = 0.25
 
-    # 1. Resolve DLL path
-    if dll_type == "url":
-        url = settings.get("injector_dll_url", "").strip()
+
+def _auto_inject_log(message):
+    LOGS.mkdir(parents=True, exist_ok=True)
+    with open(LOGS / "injector.log", "a") as log:
+        log.write(f"{message}\n")
+
+
+def _auto_inject_failed(message, detail=None):
+    _auto_inject_log(f"Auto-inject failed: {detail or message}")
+    desktop_notify(message, "DLL Injector")
+
+
+def auto_inject_download_path(url):
+    """Where a downloaded client DLL is cached, named after its own URL.
+
+    ``download`` resumes an interrupted transfer from the partial file beside
+    its destination, so one name shared by every URL splices the tail of one
+    DLL onto the head of another — a chimera that is the right length, passes
+    the transfer's own integrity check, and is then handed to LoadLibrary.
+    Hashing the URL keeps each one to itself and leaves resumption working
+    for the URL that started it.
+    """
+    digest = hashlib.sha256(url.encode("utf-8")).hexdigest()[:16]
+    return CACHE / f"auto-inject-{digest}.dll"
+
+
+def _auto_inject_dll(settings):
+    """Resolve the DLL to inject, or None once the failure has been reported."""
+    if settings.get("injector_dll_type", "file") == "url":
+        url = (settings.get("injector_dll_url") or "").strip()
         if not url:
-            with open(LOGS / "injector.log", "a") as log:
-                log.write("Auto-inject failed: URL is empty.\n")
-            from .log import desktop_notify
-            desktop_notify("Auto-inject failed: DLL URL is empty.", "DLL Injector")
-            return
+            _auto_inject_failed("Auto-inject failed: DLL URL is empty.")
+            return None
         try:
-            dest = CACHE / "downloaded_client.dll"
             from .util import download
+            dest = auto_inject_download_path(url)
             download(url, dest, label="Auto-inject DLL")
-            dll_path = dest
-        except Exception as e:
-            with open(LOGS / "injector.log", "a") as log:
-                log.write(f"Auto-inject download failed: {e}\n")
-            from .log import desktop_notify
-            desktop_notify(f"Auto-inject download failed:\n{e}", "DLL Injector")
-            return
-    else:
-        dll_path = settings.get("injector_dll_path", "").strip()
-        if not dll_path:
-            dll_path = settings.get("injector_dll", "").strip()
-        if not dll_path:
-            with open(LOGS / "injector.log", "a") as log:
-                log.write("Auto-inject failed: Local DLL path is empty.\n")
-            from .log import desktop_notify
-            desktop_notify("Auto-inject failed: Local DLL path is empty.", "DLL Injector")
-            return
-        dll_path = Path(dll_path)
+            return dest
+        except Exception as error:
+            _auto_inject_failed(f"Auto-inject download failed:\n{error}",
+                                detail=f"download: {error}")
+            return None
+    path = ((settings.get("injector_dll_path") or "").strip()
+            or (settings.get("injector_dll") or "").strip())
+    if not path:
+        _auto_inject_failed("Auto-inject failed: Local DLL path is empty.")
+        return None
+    return Path(path)
 
-    # 2. Wait for Minecraft process to start (up to 30 seconds)
-    started_wait = time.monotonic()
-    process_found = False
-    while time.monotonic() - started_wait < 30:
+
+def _await_game_process():
+    """Wait for the game to appear; False once its absence has been reported."""
+    deadline = time.monotonic() + _AUTO_INJECT_PROCESS_CEILING
+    while time.monotonic() < deadline:
         if _mc_running():
-            process_found = True
-            break
+            return True
         time.sleep(0.2)
+    _auto_inject_failed(
+        "Auto-inject failed: Minecraft process did not start.",
+        detail=(f"Minecraft process did not start within "
+                f"{_AUTO_INJECT_PROCESS_CEILING:.0f}s."))
+    return False
 
-    if not process_found:
-        with open(LOGS / "injector.log", "a") as log:
-            log.write("Auto-inject failed: Minecraft process did not start within 30s.\n")
-        from .log import desktop_notify
-        desktop_notify("Auto-inject failed: Minecraft process did not start.", "DLL Injector")
-        return
 
-    # Process is running! Record start time.
-    process_start_time = time.monotonic()
-    safety_buffer = 1.5
+def _game_window_present():
+    try:
+        from .x11 import find_presentable_window
+        return bool(find_presentable_window("minecraft.windows.exe"))
+    except Exception:
+        return False
 
-    # 3. Poll for presentable window or wait for delay
+
+def _await_injection_moment(delay):
+    """Hold until the game is ready to be injected into; False if it exited.
+
+    Two conditions have to hold. The configured delay has to have run out —
+    it is the only control the player has over a client that loads too early,
+    so a detected window never cuts it short. And the game has to have opened
+    a window, because a DLL loaded into a game that has not drawn anything yet
+    lands mid-startup; that wait is capped, since a Wayland session has no X
+    window to find and the delay alone decides there.
+    """
+    started = time.monotonic()
+    window_seen_at = None
     while True:
-        elapsed = time.monotonic() - process_start_time
-
-        try:
-            from .x11 import find_presentable_window
-            has_window = find_presentable_window("minecraft.windows.exe")
-        except Exception:
-            has_window = False
-
-        if has_window:
-            time.sleep(safety_buffer)
-            break
-
-        if elapsed >= delay:
-            break
-
+        now = time.monotonic()
         if not _mc_running():
-            return
+            return False
+        if window_seen_at is None and _game_window_present():
+            window_seen_at = now
+        waited = now - started >= delay
+        if window_seen_at is not None:
+            if waited and now - window_seen_at >= _AUTO_INJECT_WINDOW_SETTLE:
+                return True
+        elif waited and now - started >= _AUTO_INJECT_WINDOW_CEILING:
+            return True
+        time.sleep(_AUTO_INJECT_POLL)
 
-        time.sleep(0.1)
 
-    # 4. Perform injection
+def perform_auto_inject(settings):
+    """Inject the configured DLL once the game it was launched for is ready."""
+    settings = settings or {}
+    dll_path = _auto_inject_dll(settings)
+    if dll_path is None:
+        return
+    if not _await_game_process():
+        return
+    if not _await_injection_moment(float(settings.get("injector_delay", 5))):
+        return
     try:
         name = run_injector(dll_path)
-        from .log import desktop_notify
-        desktop_notify(f"Injected {name} into Minecraft. ✓", "DLL Injector")
-    except Exception as e:
-        with open(LOGS / "injector.log", "a") as log:
-            log.write(f"Auto-inject failed: {e}\n")
-        from .log import desktop_notify
-        desktop_notify(f"Could not inject:\n{e}", "DLL Injector")
+    except Exception as error:
+        _auto_inject_failed(f"Could not inject:\n{error}", detail=str(error))
+        return
+    desktop_notify(f"Injected {name} into Minecraft. ✓", "DLL Injector")
 
+
+def start_auto_inject(settings):
+    """Start this launch's auto-injection watcher, if the player asked for one.
+
+    Returns the thread it started, or None when the setting is off, so every
+    launch path can call this the same way.
+    """
+    if not (settings or {}).get("injector_auto_enable", False):
+        return None
+    watcher = threading.Thread(target=perform_auto_inject, args=(settings,),
+                               name="auto-inject", daemon=True)
+    watcher.start()
+    return watcher

--- a/bol/launch.py
+++ b/bol/launch.py
@@ -37,6 +37,7 @@ from .gpu_safety import (
     require_safe_graphics_session,
     retire_idle_current_boot_marker,
 )
+from .inject import start_auto_inject
 from .log import BolError, die, info, ok, warn
 from .ntsync import inproc_sync_problem
 from .perfcheck import (
@@ -820,6 +821,14 @@ def _launch_once(lock_fds=(), on_started=None):
             except Exception as hook_error:
                 warn("The launcher could not step aside for the game window "
                      "(%s)." % type(hook_error).__name__)
+        # Auto-injection belongs to the launch and not to whoever asked for
+        # it: a direct-launch shortcut and Game Mode both come through
+        # `bol play`, which has no GUI worker to hang the watcher off.
+        try:
+            start_auto_inject(s)
+        except Exception as inject_error:
+            warn("Automatic DLL injection could not be started (%s)."
+                 % type(inject_error).__name__)
         started = time.time()
         # Say on Discord what is being played, for as long as it is played:
         # the launcher is found by word of mouth, and this is it saying its

--- a/bol/x11.py
+++ b/bol/x11.py
@@ -530,3 +530,38 @@ def tag_steam_game_windows(app_id, wm_class, display=None, windows=None,
         if opened is None:
             return ()
         return _tag_windows(opened, wanted, value, skip)
+
+
+def find_presentable_window(wm_class, display=None):
+    wanted = str(wm_class or "").strip().lower()
+    if not wanted:
+        return False
+    target = str(display if display is not None
+                 else os.environ.get("DISPLAY", "")).strip()
+    if not target:
+        return False
+    try:
+        with _x_windows(target) as opened:
+            if opened is None:
+                return False
+            pending = [(opened.root(), 0)]
+            depth = _WINDOW_SEARCH_DEPTH
+            budget = _WINDOW_SEARCH_BUDGET
+            while pending and budget > 0:
+                window, level = pending.pop(0)
+                budget -= 1
+                names = ()
+                if level:
+                    names = tuple(str(name).lower()
+                                  for name in opened.wm_classes(window))
+                    if wanted in names:
+                        if opened.is_presentable(window):
+                            return True
+                        continue
+                if not names and level < depth:
+                    pending.extend(
+                        (child, level + 1) for child in opened.children(window))
+    except Exception:
+        pass
+    return False
+

--- a/tests/test_gui_integration.py
+++ b/tests/test_gui_integration.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
-from PySide6.QtWidgets import QMainWindow, QPushButton, QTabWidget
+from PySide6.QtWidgets import QComboBox, QMainWindow, QPushButton, QTabWidget
 from PySide6.QtTest import QSignalSpy
 
 # Ensure we can import bol modules
@@ -182,6 +182,14 @@ class TestMainWindowInitialization:
         assert main_window.hero_page is not None
         assert main_window.settings_page is not None
         assert main_window.changelog_page is not None
+
+    def test_injector_dll_load_mode_combo(self, main_window):
+        """The DLL config uses a dropdown selecting file vs URL download."""
+        combo = next((cb for cb in main_window.findChildren(QComboBox)), None)
+        assert combo is not None
+        assert combo.count() == 2
+        assert combo.itemText(0) == "File"
+        assert combo.itemText(1) == "Download"
 
 
 # ======================================================================

--- a/tests/test_inject.py
+++ b/tests/test_inject.py
@@ -2,7 +2,10 @@
 # SPDX-License-Identifier: MIT
 
 import subprocess
+import time
+from contextlib import contextmanager
 from pathlib import Path
+from types import SimpleNamespace
 from unittest import mock
 
 import pytest
@@ -276,6 +279,25 @@ def test_injector_reports_asynchronous_client_crash(tmp_path):
     assert "ERR post-injection" in (logs / "injector.log").read_text()
 
 
+@contextmanager
+def _auto_inject_env(tmp_path, window=True, delay=0.0, settle=0.0,
+                     ceiling=30.0):
+    """Drive the auto-injection watcher without a game, a window or a wait."""
+    logs = tmp_path / "logs"
+    with mock.patch.object(inject, "LOGS", logs), \
+            mock.patch.object(inject, "_mc_running", return_value=True), \
+            mock.patch.object(inject, "desktop_notify") as notify, \
+            mock.patch.object(inject, "_game_window_present",
+                              return_value=window) as present, \
+            mock.patch.object(inject, "run_injector",
+                              return_value="client.dll") as run_inj, \
+            mock.patch.object(inject, "_AUTO_INJECT_POLL", 0.01), \
+            mock.patch.object(inject, "_AUTO_INJECT_WINDOW_SETTLE", settle), \
+            mock.patch.object(inject, "_AUTO_INJECT_WINDOW_CEILING", ceiling):
+        yield SimpleNamespace(notify=notify, run_injector=run_inj,
+                              window=present, delay=delay, logs=logs)
+
+
 def test_perform_auto_inject_local_success(tmp_path):
     dll = tmp_path / "client.dll"
     dll.write_bytes(b"MZ")
@@ -283,14 +305,12 @@ def test_perform_auto_inject_local_success(tmp_path):
         "injector_auto_enable": True,
         "injector_dll_type": "file",
         "injector_dll_path": str(dll),
-        "injector_delay": 0
+        "injector_delay": 0,
     }
-    with mock.patch.object(inject, "_mc_running", return_value=True), \
-            mock.patch.object(inject, "run_injector", return_value="client.dll") as run_inj, \
-            mock.patch("bol.log.desktop_notify") as notify:
+    with _auto_inject_env(tmp_path) as env:
         inject.perform_auto_inject(settings)
-        run_inj.assert_called_once_with(Path(dll))
-        notify.assert_called_once()
+    env.run_injector.assert_called_once_with(Path(dll))
+    env.notify.assert_called_once()
 
 
 def test_perform_auto_inject_remote_success(tmp_path):
@@ -299,15 +319,100 @@ def test_perform_auto_inject_remote_success(tmp_path):
         "injector_auto_enable": True,
         "injector_dll_type": "url",
         "injector_dll_url": url,
-        "injector_delay": 0
+        "injector_delay": 0,
     }
-    with mock.patch.object(inject, "_mc_running", return_value=True), \
+    with _auto_inject_env(tmp_path) as env, \
             mock.patch.object(inject, "CACHE", tmp_path), \
-            mock.patch("bol.util.download") as download, \
-            mock.patch.object(inject, "run_injector", return_value="downloaded_client.dll") as run_inj, \
-            mock.patch("bol.log.desktop_notify") as notify:
+            mock.patch("bol.util.download") as download:
         inject.perform_auto_inject(settings)
-        download.assert_called_once_with(url, tmp_path / "downloaded_client.dll", label="Auto-inject DLL")
-        run_inj.assert_called_once_with(tmp_path / "downloaded_client.dll")
-        notify.assert_called_once()
+    dest = tmp_path / inject.auto_inject_download_path(url).name
+    download.assert_called_once_with(url, dest, label="Auto-inject DLL")
+    env.run_injector.assert_called_once_with(dest)
+    env.notify.assert_called_once()
 
+
+def test_each_download_url_caches_under_its_own_name():
+    """A shared cache name splices one interrupted DLL onto the next.
+
+    `download` resumes from the partial file beside its destination, so two
+    URLs sharing a name produce a file that is the right length, passes the
+    transfer's integrity check, and is a chimera of both.
+    """
+    first = inject.auto_inject_download_path("https://example.com/a.dll")
+    second = inject.auto_inject_download_path("https://example.com/b.dll")
+    assert first != second
+    assert first == inject.auto_inject_download_path("https://example.com/a.dll")
+    assert first.suffix == ".dll"
+
+
+def test_the_configured_delay_is_a_floor_the_window_cannot_cut_short(tmp_path):
+    """The delay is the only control over a client that loads too early."""
+    dll = tmp_path / "client.dll"
+    dll.write_bytes(b"MZ")
+    settings = {"injector_dll_type": "file", "injector_dll_path": str(dll),
+                "injector_delay": 0.4}
+    with _auto_inject_env(tmp_path, window=True) as env:
+        started = time.monotonic()
+        inject.perform_auto_inject(settings)
+        elapsed = time.monotonic() - started
+    env.run_injector.assert_called_once()
+    assert elapsed >= 0.4
+
+
+def test_injection_waits_for_the_window_past_the_delay(tmp_path):
+    """A DLL loaded into a game that has not opened yet lands mid-startup."""
+    dll = tmp_path / "client.dll"
+    dll.write_bytes(b"MZ")
+    settings = {"injector_dll_type": "file", "injector_dll_path": str(dll),
+                "injector_delay": 0}
+    with _auto_inject_env(tmp_path) as env:
+        env.window.side_effect = [False, False, False, True]
+        inject.perform_auto_inject(settings)
+    assert env.window.call_count == 4
+    env.run_injector.assert_called_once()
+
+
+def test_a_session_that_never_shows_an_x_window_still_injects(tmp_path):
+    """Wayland gives the game no X window, so that wait is capped."""
+    dll = tmp_path / "client.dll"
+    dll.write_bytes(b"MZ")
+    settings = {"injector_dll_type": "file", "injector_dll_path": str(dll),
+                "injector_delay": 0}
+    with _auto_inject_env(tmp_path, window=False, ceiling=0.2) as env:
+        inject.perform_auto_inject(settings)
+    env.run_injector.assert_called_once()
+
+
+def test_auto_inject_stops_when_the_game_exits_before_it_is_ready(tmp_path):
+    dll = tmp_path / "client.dll"
+    dll.write_bytes(b"MZ")
+    settings = {"injector_dll_type": "file", "injector_dll_path": str(dll),
+                "injector_delay": 0}
+    with _auto_inject_env(tmp_path, window=False, ceiling=5.0) as env:
+        inject._mc_running.side_effect = [True, True, False]
+        inject.perform_auto_inject(settings)
+    env.run_injector.assert_not_called()
+    env.notify.assert_not_called()
+
+
+def test_an_empty_local_path_is_reported_and_nothing_is_injected(tmp_path):
+    with _auto_inject_env(tmp_path) as env:
+        inject.perform_auto_inject({"injector_dll_type": "file"})
+    env.run_injector.assert_not_called()
+    assert "Local DLL path is empty" in (env.logs / "injector.log").read_text()
+
+
+def test_start_auto_inject_does_nothing_unless_it_was_asked_for():
+    with mock.patch.object(inject.threading, "Thread") as thread:
+        assert inject.start_auto_inject({}) is None
+        assert inject.start_auto_inject({"injector_auto_enable": False}) is None
+    thread.assert_not_called()
+
+
+def test_start_auto_inject_watches_in_the_background():
+    settings = {"injector_auto_enable": True}
+    with mock.patch.object(inject, "perform_auto_inject") as watch:
+        watcher = inject.start_auto_inject(settings)
+        assert watcher.daemon
+        watcher.join(5)
+    watch.assert_called_once_with(settings)

--- a/tests/test_inject.py
+++ b/tests/test_inject.py
@@ -274,3 +274,40 @@ def test_injector_reports_asynchronous_client_crash(tmp_path):
         with pytest.raises(BolError, match="exact Minecraft version"):
             inject.run_injector(dll)
     assert "ERR post-injection" in (logs / "injector.log").read_text()
+
+
+def test_perform_auto_inject_local_success(tmp_path):
+    dll = tmp_path / "client.dll"
+    dll.write_bytes(b"MZ")
+    settings = {
+        "injector_auto_enable": True,
+        "injector_dll_type": "file",
+        "injector_dll_path": str(dll),
+        "injector_delay": 0
+    }
+    with mock.patch.object(inject, "_mc_running", return_value=True), \
+            mock.patch.object(inject, "run_injector", return_value="client.dll") as run_inj, \
+            mock.patch("bol.log.desktop_notify") as notify:
+        inject.perform_auto_inject(settings)
+        run_inj.assert_called_once_with(Path(dll))
+        notify.assert_called_once()
+
+
+def test_perform_auto_inject_remote_success(tmp_path):
+    url = "https://example.com/client.dll"
+    settings = {
+        "injector_auto_enable": True,
+        "injector_dll_type": "url",
+        "injector_dll_url": url,
+        "injector_delay": 0
+    }
+    with mock.patch.object(inject, "_mc_running", return_value=True), \
+            mock.patch.object(inject, "CACHE", tmp_path), \
+            mock.patch("bol.util.download") as download, \
+            mock.patch.object(inject, "run_injector", return_value="downloaded_client.dll") as run_inj, \
+            mock.patch("bol.log.desktop_notify") as notify:
+        inject.perform_auto_inject(settings)
+        download.assert_called_once_with(url, tmp_path / "downloaded_client.dll", label="Auto-inject DLL")
+        run_inj.assert_called_once_with(tmp_path / "downloaded_client.dll")
+        notify.assert_called_once()
+

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -1228,6 +1228,61 @@ class LaunchStartedHookTests(ReadyLaunchHarness, unittest.TestCase):
         once.assert_called_once_with((71, 72), on_started=hook)
 
 
+class AutoInjectionLaunchTests(ReadyLaunchHarness, unittest.TestCase):
+    """Auto-injection belongs to the launch, not to the window that asked."""
+
+    def _play(self, settings, start_fails=False):
+        events = []
+
+        def popen(*_a, **_kw):
+            events.append("spawned")
+            proc = mock.Mock()
+            proc.wait.side_effect = lambda timeout=None: (
+                events.append("waited") or 0)
+            return proc
+
+        def start(passed):
+            events.append("auto-inject")
+            if start_fails:
+                raise RuntimeError("no thread")
+            self.injected_settings = passed
+            return mock.Mock()
+
+        self.injected_settings = None
+        with tempfile.TemporaryDirectory() as td, \
+                mock.patch.object(launch, "start_auto_inject",
+                                  side_effect=start) as started:
+            rc = self._exercise_ready_launch(
+                Path(td), popen,
+                arm=lambda: "owned-token",
+                disarm=lambda _token: True,
+                extra_settings=settings,
+            )
+        return rc, events, started
+
+    def test_a_launcher_free_launch_still_injects(self):
+        """`bol play` is what a direct-launch shortcut and Game Mode run."""
+        rc, events, started = self._play({"injector_auto_enable": True})
+        self.assertEqual(rc, 0)
+        self.assertEqual(events, ["spawned", "auto-inject", "waited"])
+        started.assert_called_once()
+        self.assertTrue(self.injected_settings["injector_auto_enable"])
+
+    def test_the_watcher_is_offered_every_launch_and_declines_by_default(self):
+        rc, events, started = self._play({})
+        self.assertEqual(rc, 0)
+        self.assertEqual(events, ["spawned", "auto-inject", "waited"])
+        self.assertFalse(started.call_args.args[0].get("injector_auto_enable"))
+
+    def test_a_watcher_that_cannot_start_never_aborts_a_running_game(self):
+        rc, events, _started = self._play({"injector_auto_enable": True},
+                                          start_fails=True)
+        self.assertEqual(rc, 0)
+        self.assertEqual(events, ["spawned", "auto-inject", "waited"])
+        self.assertTrue(any("Automatic DLL injection" in warning
+                            for warning in self._warnings()))
+
+
 if __name__ == "__main__":
     unittest.main()
 


### PR DESCRIPTION
Added support for auto-injecting a client DLL when Minecraft starts
Added settings for the injector:
local file path
URL-based download
injection delay
auto-enable option
Kept the remote/local behavior mutually exclusive via a DLL load mode selector
Wired the injector to resolve either a downloaded DLL or a local file before launch
Added GUI and injection tests covering both local and remote DLL flows
