### PR TITLE
Fix _TOTAL_BAR regex pattern matching

### DIFF
--- a/bol/xodus.py
+++ b/bol/xodus.py
@@ -115,7 +115,14 @@ _PROGRESS = re.compile(
     r"(?P<total>[\d.]+)\s*(?P<tu>[KMGT]?i?B)")
 _UNITS = {"B": 1, "KiB": 1 << 10, "MiB": 1 << 20, "GiB": 1 << 30,
           "TiB": 1 << 40}
-_TOTAL_BAR = re.compile(r"^(initializing|downloading)", re.I)
+# Only the label is checked, and it has to be the *whole* label: a per-file
+# or per-segment bar can be captioned "Downloading <name>", and a prefix
+# match would take that for the aggregate bar too. Its own total is a single
+# file, almost always small next to the whole package, so for one frame the
+# launcher would report progress against the wrong denominator entirely --
+# a percentage that has nothing to do with the real download -- until the
+# next line carrying the real "Downloading" bar corrects it (#223).
+_TOTAL_BAR = re.compile(r"^(initializing|downloading)\s*$", re.I)
 _ANSI = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
 # ld.so, not Xodus: "…/xodus-cli: error while loading shared libraries:
 # libwebkit2gtk-4.1.so.0: cannot open shared object file: No such file or

--- a/tests/test_xodus.py
+++ b/tests/test_xodus.py
@@ -776,6 +776,26 @@ class ProgressTests(unittest.TestCase):
             tail, lambda done, total: captured.append((done, total)))
         self.assertEqual(captured, [(431 << 20, 862 << 20)])
 
+    def test_a_segment_bar_labelled_downloading_is_not_the_total_bar(self):
+        # #223: a per-file/segment bar can be captioned "Downloading <name>"
+        # rather than a bare filename. A prefix match on "downloading" would
+        # take its own (small, near-full) total for the aggregate one, and
+        # the launcher would show a percentage against the wrong package
+        # entirely for a frame -- "off the rails" until the real bar, whose
+        # label is exactly "Downloading", corrects it.
+        seen = []
+        tail = []
+        xodus._consume(
+            "Downloading segment_0000.msixvc    3.90 MiB/    4.00 MiB",
+            tail, seen.append)
+        self.assertEqual(seen, [])
+
+        captured = []
+        xodus._consume(
+            "Downloading    12.00 MiB/    862.00 MiB     12.00 MiB [#] 1%",
+            tail, lambda done, total: captured.append((done, total)))
+        self.assertEqual(captured, [(12 << 20, 862 << 20)])
+
     def test_a_session_without_a_terminal_still_gets_the_bars_drawn(self):
         # A launcher started from a desktop entry, Steam or Game Mode passes
         # no TERM, and indicatif draws nothing when TERM says the terminal


### PR DESCRIPTION
Problem
The launcher briefly prints an invalid download percentage before
settling into a normal 0-100% bar, then launches fine (#223).

Root cause
`_TOTAL_BAR` matched on the prefix of a progress bar's label
(`^(initializing|downloading)`), not the whole label. The real
aggregate bar's label is exactly "Downloading", but a per-file or
per-segment bar can be captioned "Downloading <name>" — same prefix.
That segment's own tiny, near-complete total briefly gets read as the
whole package's total, so the percentage is computed against the
wrong denominator for one frame, until the next line (the real
aggregate bar) corrects it.

The Fix:
Anchor `_TOTAL_BAR` to the full label instead of a prefix match:

    _TOTAL_BAR = re.compile(r"^(initializing|downloading)\s*$", re.I)

Testing
- `pytest tests/test_xodus.py` — 83 passed
- Added `test_a_segment_bar_labelled_downloading_is_not_the_total_bar`,
  which feeds `_consume` a "Downloading segment_0000.msixvc" line and
  asserts it's ignored, then confirms the real aggregate bar still
  drives progress correctly

Closes #223