### PR TITLE
fix(flake.nix): include libxcompose to steam-run

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,9 @@
         python-xlib
         certifi
       ]);
+      steam-run = pkgs.steam-run.override (prev: {
+        targetPkgs = pkgs: prev.targetPkgs pkgs ++ [ pkgs.libxcomposite ];
+      });
     in
     {
       packages.x86_64-linux.default = pkgs.stdenv.mkDerivation {
@@ -37,7 +40,7 @@
           cp data/bedrock-on-linux.desktop $out/share/applications/
           cp data/icon.png $out/share/icons/hicolor/256x256/apps/bedrock-on-linux.png
 
-          makeWrapper ${pkgs.steam-run}/bin/steam-run $out/bin/bedrock-on-linux \
+          makeWrapper ${steam-run}/bin/steam-run $out/bin/bedrock-on-linux \
             --add-flags "${bolPython}/bin/python3" \
             --add-flags "$out/lib/bedrock-on-linux/bedrock-on-linux" \
             --prefix PYTHONPATH : "$out/lib/bedrock-on-linux"


### PR DESCRIPTION
# Bug
I'm running BedrockOnLinux on NixOS using the command:
```bash
nix run github:Wyze3306/BedrockOnLinux
```
When I try downloading the latest version of Minecraft Bedrock the following error appears:
<img width="997" height="603" alt="report" src="https://github.com/user-attachments/assets/ebd42f73-325e-4f6a-aadf-40382a5cda7c" />

# Solution
After digging into it a bit, I've found out `steam-run` was not finding `libxcompose`.
So I fixed it by overriding `steam-run` and adding `pkgs.libxcompose` to `targetPkgs`.

My changes can be tested running:
```bash
nix run github:Claudiney-Santos/BedrockOnLinux/fix/libxcompose
```