### PR TITLE
Fix stale Minecraft articles leaking past the version filter (date parsed as version)

### DIFF
--- a/bol/util.py
+++ b/bol/util.py
@@ -482,6 +482,17 @@ def mc_releases(fetch_all=True, ignore_cache=False):
         for m in matches:
             parts = [int(x) if x else 0 for x in m]
             if parts[0] > 10:
+                # Article titles often carry a "YYYY.MM.DD"-style release
+                # date alongside the real version (e.g. "1.19.0, released
+                # 2023.05.01"). Without a ceiling, a 4+ digit year gets
+                # misread as an old-style "<major>.<minor>" version and
+                # reinterpreted as e.g. (1, 2023, 5, 1) -- which is high
+                # enough to pass the "recent version" filter below and lets
+                # a stale article slip back into the list. Minecraft's own
+                # version components never reach 1000, so anything at or
+                # above that is a date, not a version, and is dropped.
+                if parts[0] > 999:
+                    continue
                 parts = [1, parts[0], parts[1], parts[2]]
             res.append(tuple(parts))
         return res


### PR DESCRIPTION
## What's wrong

`mc_releases()` in `bol/util.py` filters official Minecraft changelog
articles down to "recent" ones using `extract_versions()`, which regex-matches
any `\d+.\d+` pattern in the article title as a version number. It also has a
heuristic that reinterprets a leading number >10 as an "old-style" version
(e.g. `21.130.25` → `1.21.130.25`).

The problem is that article titles often also contain a **release date**,
like `2023.05.01`. That date gets caught by the same regex and, because the
year is well above 10, gets "reinterpreted" as a version — e.g.
`(1, 2023, 5, 1)` — which is absurdly high and always passes the
`>= (1, 21, 120, 0)` recency check.

Net effect: an old/stale article can slip back into the "current" list just
because its title happens to contain a date, defeating the filter.

Repro:

    title = "Minecraft 1.19.0 hotfix, released 2023.05.01"
    extract_versions(title)
    # before: [(1, 19, 0, 0), (1, 2023, 5, 1)]  -> passes the recency filter
    # after:  [(1, 19, 0, 0)]                    -> correctly filtered out

## The fix

Cap the "old-style" reinterpretation at 999. Minecraft version components
never reach four digits, so anything ≥1000 is a date, not a version, and gets
dropped instead of misread.

## Testing

Full test suite passes (1191 passed, 7 skipped). Manually verified the repro
above, plus confirmed normal versioned titles (`1.21.130.25`, `21.130.25`)
still parse correctly.

---

Small note: I recently switched to Windows — I got tired of fighting with Linux on a daily basis. Unfortunately, open source has become increasingly politicized, and I couldn't just stand by and watch. So I likely won't be around to keep contributing to this repo going forward. I wanted to send one last useful PR before I go. Thanks for building and maintaining BedrockOnLinux — it's been a great project to use and explore. 🙏
