### PR TITLE
fix(auth): reuse a fresh Xbox Live token chain at PLAY instead of refetching it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **PLAY no longer redoes an Xbox Live sign-in it already just finished.**
+  Every launch minted a fresh device, user, XBL, XSTS and SISU token chain —
+  eight sequential requests to Microsoft/Xbox — even when the previous launch
+  had done exactly that a minute earlier and the tokens were still good for
+  hours. The background warm-up that runs while you're still looking at the
+  account row (`_warm_xbox_preauth`) already does this work; PLAY was simply
+  throwing it away and starting over, worth roughly ten seconds of the wait
+  before Minecraft's window appears. PLAY now reuses a cached token chain
+  when it still has a comfortable margin left, and only re-runs the chain
+  when that margin has run out or the tokens are missing outright.
+
 ## 2.2.5 — 2026-08-31
 
 ### Added

--- a/bol/auth.py
+++ b/bol/auth.py
@@ -420,6 +420,13 @@ _ONLINE_PREAUTH_REQUIREMENTS = {
 }
 
 
+# How much validity a cached online payload has to have left before a launch
+# reuses it instead of re-running the whole device/user/XSTS/SISU chain. Wide
+# enough to cover a play session so PLAY doesn't sign off mid-game; far
+# short of the hours-long lifetime Xbox actually issues these tokens with.
+_PREAUTH_REUSE_MARGIN = 1800
+
+
 _WINEGDK_EXPIRY_EPOCH_FIELDS = {
     "user_token_expiry": "user_token_expiry_epoch",
     "xbl_token_expiry": "xbl_token_expiry_epoch",
@@ -843,8 +850,37 @@ def xbl_preauth(msa_access_token, expected_account_epoch=None,
              "pre-auth started; refusing stale credentials.")
         return False
     cached = _load_online_preauth(out_path)
+    # A comfortable margin, not just the floor that keeps a cache usable at
+    # all: a launch that reuses it should not sign off mid-session.
     cached_ready = (_cached_account_matches(cached, account_epoch)
-                    and not _online_preauth_problems(cached))
+                    and not _online_preauth_problems(
+                        cached, min_ttl=_PREAUTH_REUSE_MARGIN))
+
+    def _keep_cache(log=info):
+        """Store WineGDK's epoch fields onto ``cached`` if missing, then use it."""
+        upgraded = _with_winegdk_expiry_epochs(cached)
+        if upgraded != cached:
+            if not _store_online_preauth(
+                    out_path, upgraded, expected_epoch=account_epoch):
+                warn("Xbox Live pre-auth: account changed while upgrading "
+                     "the cached WineGDK credentials; refusing the old "
+                     "online payload.")
+                return False
+            cached.clear()
+            cached.update(upgraded)
+            info("Xbox Live pre-auth: upgraded cached token expirations "
+                 "for WineGDK.")
+        log("Xbox Live pre-auth: keeping the complete unexpired cached "
+            "online tokens.")
+        _clear_xbl_preauth_diagnostic()
+        return True
+
+    # A fresh cache is worth more than a fresh network round trip: the GUI
+    # already warms this chain in the background while the player is still
+    # looking at the account row (see _warm_xbox_preauth), so PLAY redoing
+    # eight sequential HTTP calls it just finished is pure latency.
+    if cached_ready and _keep_cache(log=ok):
+        return True
 
     def _fallback(message, stage=None, category=None, response=None):
         if response is not None:
@@ -862,22 +898,7 @@ def xbl_preauth(msa_access_token, expected_account_epoch=None,
             and not _online_preauth_problems(cached)
         )
         if current_ready:
-            upgraded = _with_winegdk_expiry_epochs(cached)
-            if upgraded != cached:
-                if not _store_online_preauth(
-                        out_path, upgraded, expected_epoch=account_epoch):
-                    warn("Xbox Live pre-auth: account changed while upgrading "
-                         "the cached WineGDK credentials; refusing the old "
-                         "online payload.")
-                    return False
-                cached.clear()
-                cached.update(upgraded)
-                info("Xbox Live pre-auth: upgraded cached token expirations "
-                     "for WineGDK.")
-            info("Xbox Live pre-auth: keeping the complete unexpired cached "
-                 "online tokens.")
-            _clear_xbl_preauth_diagnostic()
-            return True
+            return _keep_cache()
         if cached_ready and current_epoch == account_epoch:
             warn("Xbox Live pre-auth: cached online tokens expired while the "
                  "refresh was in progress; refusing stale credentials.")

--- a/bol/gui.py
+++ b/bol/gui.py
@@ -2160,9 +2160,10 @@ class MainWindow(QMainWindow):
     def _warm_xbox_preauth(self):
         """Mint the Xbox token chain now rather than at PLAY.
 
-        launch.py runs xbl_preauth again on its own, so nothing breaks
-        without this -- it just moves the whole SISU/XSTS round trip off the
-        first launch and into the moment the player is already waiting on a
+        launch.py calls xbl_preauth again on its own, so nothing breaks
+        without this -- but a still-fresh cache from here is what lets that
+        call skip its network round trip, moving the whole SISU/XSTS chain
+        off PLAY and into the moment the player is already waiting on a
         sign-in. It also settles the account row: the row goes green on the
         MSA token alone, and only this says whether Xbox agreed.
         """

--- a/tests/test_auth_settings.py
+++ b/tests/test_auth_settings.py
@@ -4,6 +4,7 @@
 import json
 import stat
 import tempfile
+import time
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -583,6 +584,62 @@ class OnlinePreauthPayloadTests(unittest.TestCase):
                     mock.patch.object(auth, "warn"), \
                     mock.patch.object(auth, "info"):
                 self.assertFalse(auth.xbl_preauth("fresh-access-token"))
+
+    def test_fresh_cache_skips_the_network_chain(self):
+        """PLAY should not redo what _warm_xbox_preauth just finished."""
+        epoch = "b" * 32
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            cache = root / "winegdk-preauth"
+            cache.mkdir()
+            (cache / ".account-epoch").write_text(epoch + "\n")
+            payload = self.payload()
+            payload["_account_epoch"] = epoch
+            auth._store_online_preauth(cache / "device.json", payload,
+                                       expected_epoch=epoch)
+
+            with mock.patch.object(auth, "DATA", root), \
+                    mock.patch("urllib.request.urlopen") as urlopen, \
+                    mock.patch.object(auth, "warn"), \
+                    mock.patch.object(auth, "info"), \
+                    mock.patch.object(auth, "ok"):
+                self.assertTrue(
+                    auth.xbl_preauth("fresh-access-token", epoch))
+
+            urlopen.assert_not_called()
+
+    def test_cache_inside_reuse_margin_still_refreshes(self):
+        """A cache that clears the 60s floor but not the reuse margin still
+        drives a real refresh, so a session doesn't sign off mid-play."""
+        from datetime import datetime, timezone
+
+        epoch = "c" * 32
+        soon = datetime.fromtimestamp(
+            time.time() + auth._PREAUTH_REUSE_MARGIN / 2, tz=timezone.utc
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            cache = root / "winegdk-preauth"
+            cache.mkdir()
+            (cache / ".account-epoch").write_text(epoch + "\n")
+            payload = self.payload(soon)
+            payload["_account_epoch"] = epoch
+            auth._store_online_preauth(cache / "device.json", payload,
+                                       expected_epoch=epoch)
+
+            with mock.patch.object(auth, "DATA", root), \
+                    mock.patch("urllib.request.urlopen",
+                               side_effect=OSError("simulated timeout")) \
+                    as urlopen, \
+                    mock.patch.object(auth, "warn"), \
+                    mock.patch.object(auth, "info"):
+                # The network attempt is made (not skipped) even though it
+                # then fails; the still-valid cache is what recovers True
+                # here, via the offline-resilience fallback, not the reuse
+                # fast path this test is guarding.
+                auth.xbl_preauth("fresh-access-token", epoch)
+
+            urlopen.assert_called()
 
     def test_achievements_use_user_only_xsts_and_services_keep_sisu(self):
         expiry = "2999-01-01T00:00:00.1234567Z"


### PR DESCRIPTION
## Summary
- PLAY re-ran the full device/user/XBL/XSTS/SISU chain (eight sequential HTTP round trips) on every launch, even right after `_warm_xbox_preauth` had just minted the same tokens with hours of validity left — about 10s of every launch's wait spent redoing work that was already done.
- `xbl_preauth` now reuses the cached online payload when it still clears a 30-minute margin, and only re-runs the chain once that margin is gone (or the cache is missing/stale), so a warm background sign-in actually gets used at PLAY.
- The offline-resilience fallback (a network failure mid-refresh falling back to a still-valid cache) is untouched — it still uses its own thin 60s margin.

## Test plan
- [x] `python -m pytest tests/test_auth_settings.py tests/test_auth_errors.py -q` — added two new tests: a fresh cache skips the network entirely, and a cache below the reuse margin still drives a real refresh.
- [x] `python -m pytest tests/ -q` — full suite passes (one pre-existing, unrelated failure on this machine from a missing `rpm` CLI, reproduced on `main`).